### PR TITLE
MCS-17 Fixed pausing the physics simulation between player steps.

### DIFF
--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -134,6 +134,30 @@ MonoBehaviour:
   agents: []
   actionDuration: 3
   AdvancePhysicsStepCount: 0
+--- !u!1 &79736621 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1762336587455144, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &109201275 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1908917868031352, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &113322161 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1433222673180860, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &136991460 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1097950301914820, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &151436664
 GameObject:
   m_ObjectHideFlags: 0
@@ -203,6 +227,60 @@ Transform:
   m_Father: {fileID: 2130836427}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &191928985 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1501777502899760, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &251218508 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1252970257981572, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &273787969 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1705092847067678, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &327230460 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1001576541782004, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &344821538 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1842833903112120, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &345501610 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1033293094319932, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &346112519 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1941900213557218, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &371361170 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1566522776473982, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &373031739 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1340499340313870, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &411097254
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1834,9 +1912,192 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 114125549759153004, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 3a963756b61df410c91df72a73d4efde, type: 3}
+--- !u!1 &458248787 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1569387858830278, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &497714281 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 256261900328249901, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &506323128 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 100000, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &506323129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506323128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 43a78934932c61bd3bb5c4c6bf65eb36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IsWalking: 0
+  m_WalkSpeed: 0
+  m_RunSpeed: 0
+  m_GravityMultiplier: 2
+  imageSynthesis: {fileID: 0}
+  VisibilityCapsule: {fileID: 513116322}
+  TallVisCap: {fileID: 1238378686}
+  BotVisCap: {fileID: 513116322}
+  agentManager: {fileID: 0}
+  excludeObjectIds: []
+  m_Camera: {fileID: 0}
+  m_CharacterController: {fileID: 0}
+  actionComplete: 0
+  standingLocalCameraPosition: {x: 0, y: 0, z: 0}
+  crouchingLocalCameraPosition: {x: 0, y: 0, z: 0}
+  maxVisibleDistance: 1.5
+  actionDuration: 3
+  ToSetActive:
+  - {fileID: 373031739}
+  - {fileID: 937954344}
+  - {fileID: 935738070}
+  - {fileID: 1373255664}
+  PhysicsAgentSkinWidth: 0.001
+  AgentHand: {fileID: 373031739}
+  DefaultHandPosition: {fileID: 937954344}
+  ItemInHand: {fileID: 0}
+  RotateRLPivots:
+  - {fileID: 1981131965}
+  - {fileID: 848572087}
+  - {fileID: 371361170}
+  - {fileID: 1068440752}
+  - {fileID: 113322161}
+  - {fileID: 673066188}
+  - {fileID: 616426704}
+  - {fileID: 860729291}
+  - {fileID: 1053499892}
+  - {fileID: 136991460}
+  - {fileID: 681115220}
+  - {fileID: 1125265186}
+  RotateRLTriggerBoxes:
+  - {fileID: 346112519}
+  - {fileID: 1967763064}
+  - {fileID: 1524469442}
+  - {fileID: 273787969}
+  - {fileID: 109201275}
+  - {fileID: 327230460}
+  - {fileID: 1714477664}
+  - {fileID: 2079819806}
+  - {fileID: 1777678740}
+  - {fileID: 1183962244}
+  - {fileID: 458248787}
+  - {fileID: 345501610}
+  LookUDPivots:
+  - {fileID: 1460899622}
+  - {fileID: 79736621}
+  - {fileID: 1049511453}
+  - {fileID: 344821538}
+  - {fileID: 1184853362}
+  - {fileID: 761303586}
+  LookUDTriggerBoxes:
+  - {fileID: 191928985}
+  - {fileID: 533477796}
+  - {fileID: 1272405812}
+  - {fileID: 2119012645}
+  - {fileID: 1246799801}
+  - {fileID: 251218508}
+  VisibleSimObjPhysics: []
+  IsHandDefault: 1
+  FlightMode: 0
+  FlightCameras: []
+  objectIdsInBox: []
+  inTopLevelView: 0
+  lastLocalCameraPosition: {x: 0, y: 0, z: 0}
+  lastLocalCameraRotation: {x: 0, y: 0, z: 0, w: 0}
+  cameraOrthSize: 0
+  reachablePositions: []
+  alwaysReturnVisibleRange: 0
+  ScreenFaces:
+  - {fileID: 2100000, guid: 3244a00d10815aa4b8ca6f11febd11f9, type: 2}
+  - {fileID: 2100000, guid: 7b776d33d2e7db4499b93e29978400ea, type: 2}
+  - {fileID: 2100000, guid: 3e9ce1cb292fb6442984e83b779c6e72, type: 2}
+  - {fileID: 2100000, guid: 7a57fbb1753fd1d40893e3d4e4c3a02b, type: 2}
+  MyFaceMesh: {fileID: 497714281}
+  sceneBounds:
+    m_Center: {x: Infinity, y: Infinity, z: Infinity}
+    m_Extent: {x: -Infinity, y: -Infinity, z: -Infinity}
+  step: 0
+--- !u!1 &513116322 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1762015268591634, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &533477796 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1002011983626484, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &616426704 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1562896084355886, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &673066188 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1614954115685630, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &681115220 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1335624823440574, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &761303586 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1992889102413810, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &848572087 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1989392704526640, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &860729291 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1358326625410892, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &935738070 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1890475479083370, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &937954344 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1863262018947090, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1049511453 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1770011199238814, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1053499892 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1200981226583862, guid: 5e9e851c0e142814dac026a256ba2ac0,
     type: 3}
   m_PrefabInstance: {fileID: 1752557968}
   m_PrefabAsset: {fileID: 0}
@@ -1962,6 +2223,30 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 3
+--- !u!1 &1068440752 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1577045921580366, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1125265186 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1290111961993776, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1183962244 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1625553241098532, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1184853362 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1982650264962640, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1229610369
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1969,6 +2254,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1083149744313030, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 224778784152956280, guid: 5b3a2f458d83e4af9a41ecf71b1f80f8,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -2104,6 +2393,30 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1238378686 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 256261900933697183, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1246799801 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1295174683097672, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1272405812 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1289070211988850, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1373255664 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1673061887459306, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1381832264
 GameObject:
   m_ObjectHideFlags: 0
@@ -2226,6 +2539,12 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 3
+--- !u!1 &1460899622 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1307686997440558, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1491039901
 GameObject:
   m_ObjectHideFlags: 0
@@ -2470,6 +2789,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 3
+--- !u!1 &1524469442 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1338297802647844, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1714477664 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1051516223651878, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1752557968
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2585,8 +2916,21 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    - target: {fileID: 114749714472260818, guid: 5e9e851c0e142814dac026a256ba2ac0,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 114749714472260818, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
+    - {fileID: 2433281640897831673, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
+--- !u!1 &1777678740 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1784381909192596, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1841293342
 GameObject:
   m_ObjectHideFlags: 0
@@ -2741,7 +3085,6 @@ MonoBehaviour:
   defaultSceneFile: 
   enableVerboseLog: 0
   objectRegistryFile: object_registry
-  physicsFrameDuration: 10
 --- !u!4 &1891392285
 Transform:
   m_ObjectHideFlags: 0
@@ -2792,6 +3135,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1967763064 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1208291715876506, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1981131965 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1029209129405524, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2065516556
 GameObject:
   m_ObjectHideFlags: 0
@@ -2914,6 +3269,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 3
+--- !u!1 &2079819806 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1586169677395318, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2119012645 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1168458656442288, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2130836426
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -42,7 +42,7 @@ public class AgentManager : MonoBehaviour
 
     private JavaScriptInterface jsInterface;
 
-    private PhysicsSceneManager physicsSceneManager;
+    protected PhysicsSceneManager physicsSceneManager;
     public int AdvancePhysicsStepCount = 0;
 
 	void Awake() {
@@ -97,7 +97,7 @@ public class AgentManager : MonoBehaviour
 
 	}
 	
-	public virtual void Initialize(ServerAction action)
+	public void Initialize(ServerAction action)
 	{
         if (action.agentType != null && action.agentType.ToLower() == "stochastic") {
             this.agents.Clear();
@@ -284,14 +284,14 @@ public class AgentManager : MonoBehaviour
         return false;
     }
 
-	public virtual void setReadyToEmit(bool readyToEmit) {
+	public void setReadyToEmit(bool readyToEmit) {
 		this.readyToEmit = readyToEmit;
 	}
 
     // Decide whether agent has stopped actions
     // And if we need to capture a new frame
 
-    private void Update()
+    public virtual void Update()
     {
         physicsSceneManager.isSceneAtRest = true;//assume the scene is at rest by default
     }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -231,7 +231,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
 		abstract public Vector3[] getReachablePositions(float gridMultiplier=1.0f, int maxStepCount = 10000);
 
-		public void Initialize(ServerAction action)
+		public virtual void Initialize(ServerAction action)
         {
 
             if(action.agentMode.ToLower() == "tall" || action.agentMode.ToLower() == "bot")
@@ -639,7 +639,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		}
 
 
-		public void ProcessControlCommand(ServerAction controlCommand)
+		public virtual void ProcessControlCommand(ServerAction controlCommand)
 		{
             currentServerAction = controlCommand;
 			

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -29,7 +29,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 Cursor.visible = true;
                 Cursor.lockState = CursorLockMode.None;
             }
-            
+
+            ServerAction action = new ServerAction();
+            action.action = "Initialize";
+            PhysicsController.ProcessControlCommand(action);
         }
 
         public void OnEnable() {

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using UnityEngine;
+using UnityStandardAssets.Characters.FirstPerson;
+
+public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
+    public static int PHYSICS_SIMULATION_STEPS = 20;
+    public int step = 0;
+
+    public override void Initialize(ServerAction action) {
+        base.Initialize(action);
+
+        // Reset the MCS scene configuration data and player.
+        this.step = 0;
+        MachineCommonSenseMain main = GameObject.Find("MCS").GetComponent<MachineCommonSenseMain>();
+        main.enableVerboseLog = action.logs;
+        main.ChangeCurrentScene(action.sceneConfig);
+    }
+
+    public override void ProcessControlCommand(ServerAction controlCommand) {
+        base.ProcessControlCommand(controlCommand);
+
+        // Call Physics.Simulate multiple times with a small step value because a large step
+        // value causes collision errors.  From the Unity Physics.Simulate documentation:
+        // "Using step values greater than 0.03 is likely to produce inaccurate results."
+        for (int i = 0; i < MachineCommonSenseController.PHYSICS_SIMULATION_STEPS; ++i) {
+            Physics.Simulate(0.01f);
+        }
+
+        this.step++;
+    }
+}

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs.meta
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43a78934932c61bd3bb5c4c6bf65eb36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Scripts/MachineCommonSensePerformerManager.cs
+++ b/unity/Assets/Scripts/MachineCommonSensePerformerManager.cs
@@ -2,18 +2,9 @@
 using UnityEngine;
 
 public class MachineCommonSensePerformerManager : AgentManager {
-    public static int step = 0;
-    public void FinalizeEmit() {
-        base.setReadyToEmit(true);
-    }
-    public override void Initialize(ServerAction action) {
-        base.Initialize(action);
-        MachineCommonSensePerformerManager.step = 0;
-        MachineCommonSenseMain main = GameObject.Find("MCS").GetComponent<MachineCommonSenseMain>();
-        main.enableVerboseLog = action.logs;
-        main.ChangeCurrentScene(action.sceneConfig);
-    }
-    public override void setReadyToEmit(bool readyToEmit) {
-        MachineCommonSensePerformerManager.step++;
+    public override void Update() {
+        base.Update();
+        // Our scene is never at rest (it is always moving)!
+        this.physicsSceneManager.isSceneAtRest = false;
     }
 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -43,7 +43,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
         // Extra stuff
         private PhysicsSceneManager _physicsSceneManager = null;
-        private PhysicsSceneManager physicsSceneManager
+        protected PhysicsSceneManager physicsSceneManager
         {
             get {
                 if (_physicsSceneManager == null) {

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -698,7 +698,7 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj
 #endif
 
     // Use this for initialization
-    void Start()
+    public void Start()
 	{
 		//For debug in editor only
 #if UNITY_EDITOR

--- a/unity/Assets/Scripts/SimObjType.cs
+++ b/unity/Assets/Scripts/SimObjType.cs
@@ -254,6 +254,8 @@ public enum SimObjType : int
 	ShowerHead = 146,
     TVStand = 147,
     CoffeeTable = 148,
+
+    MachineCommonSenseObject = 999999999
 }
 
 public static class ReceptacleRestrictions


### PR DESCRIPTION
Updates for ticket MCS-17:
- MCS dynamically generated physics objects are now AI2-THOR `SimObjPhys` objects.  (See `MachineCommonSenseMain.AssignProperties`)
- Created the `MachineCommonSenseController` to replace the AI2-THOR `PhysicsRemoteFPSAgentController`.
- Replaced the old physics simulation behavior from `MachineCommonSenseMain.Update` with calls to `Physics.Simulate` in `MachineCommonSenseController.ProcessControlCommand`.

Other updates:
- Moved custom `Initialize` behavior from `MachineCommonSensePerformerManager` to `MachineCommonSenseController`.
- Added call to `Initialize` in `DebugDiscreteAgentController`.
- Added changes and workflows to our README file.
