### PR TITLE
MCS-21 - Override RotateLook

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,5 @@ Alternatively, if you want to build the Unity project via the command line, run 
   - Added a `MachineCommonSenseObject` type
 - `Shaders/DepthBW`:
   - Changed the divisor to increase the effective depth of field for the depth masks.
-
+- `Scripts/MachineCommonSenseController`:
+  - Added custom `RotateLook` to use relative inputs instead of absolute values.

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.6995551, g: 0.7222365, b: 0.7302953, a: 1}
+  m_IndirectSpecularColor: {r: 0.69955504, g: 0.7222365, b: 0.7302953, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3082,7 +3082,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 940f8586c495e37cc80926a37e932c65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSceneFile: sample1
+  defaultSceneFile: 
   enableVerboseLog: 0
   objectRegistryFile: object_registry
 --- !u!4 &1891392285

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.69955504, g: 0.7222365, b: 0.7302953, a: 1}
+  m_IndirectSpecularColor: {r: 0.6995551, g: 0.7222365, b: 0.7302953, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3082,7 +3082,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 940f8586c495e37cc80926a37e932c65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSceneFile: 
+  defaultSceneFile: sample1
   enableVerboseLog: 0
   objectRegistryFile: object_registry
 --- !u!4 &1891392285

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -954,7 +954,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		}
 
 		//looks like thisfree rotates AND free changes camera look angle?
-		public void RotateLook(ServerAction response)
+		public virtual void RotateLook(ServerAction response)
 		{
 			transform.rotation = Quaternion.Euler(new Vector3(0.0f, response.rotation.y, 0.0f));
 			m_Camera.transform.localEulerAngles = new Vector3(response.horizon, 0.0f, 0.0f);

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -10,9 +10,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
         public GameObject InputFieldObj = null;
         public PhysicsRemoteFPSAgentController PhysicsController = null;
         private InputField inputField;
-        public float angle = 0;
-        public float angleIncrement = 45.0f;
-        public int horizon = 0;
+        public float rotationIncrement = 45.0f;
         public int horizonIncrement = 30;
 
         [SerializeField] private GameObject InputMode_Text = null;
@@ -259,21 +257,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         {
                             ServerAction action = new ServerAction();
 
-                            // Limiting where to look based on realistic expectation (for instance, a person can't turn
-                            // their head 180 degrees)
-                            if (horizon == -90)
-                            {
-                                horizonIncrement = 30;
-                            }
-                            else if (horizon == 90)
-                            {
-                                horizonIncrement = -30;
-                            }
-
-                            horizon += horizonIncrement;
-                            angle += angleIncrement;
-                            action.rotation.y = angle;
-                            action.horizon = horizon;
+                            action.rotation.y = rotationIncrement;
+                            action.horizon = horizonIncrement;
 
                             action.action = "RotateLook";
                             PhysicsController.ProcessControlCommand(action);

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -10,6 +10,10 @@ namespace UnityStandardAssets.Characters.FirstPerson
         public GameObject InputFieldObj = null;
         public PhysicsRemoteFPSAgentController PhysicsController = null;
         private InputField inputField;
+        public float angle = 0;
+        public float angleIncrement = 45.0f;
+        public int horizon = 0;
+        public int horizonIncrement = 30;
 
         [SerializeField] private GameObject InputMode_Text = null;
         // Start is called before the first frame update
@@ -246,6 +250,30 @@ namespace UnityStandardAssets.Characters.FirstPerson
                                 action.action = "CheckDroneCaught";
                                 PhysicsController.ProcessControlCommand(action);
                             }
+                        }
+
+                        if(Input.GetKeyDown(KeyCode.R))
+                        {
+                            ServerAction action = new ServerAction();
+
+                            // Limiting where to look based on realistic expectation (for instance, a person can't turn
+                            // their head 180 degrees)
+                            if (horizon == -90)
+                            {
+                                horizonIncrement = 30;
+                            }
+                            else if (horizon == 90)
+                            {
+                                horizonIncrement = -30;
+                            }
+
+                            horizon += horizonIncrement;
+                            angle += angleIncrement;
+                            action.rotation.y = angle;
+                            action.horizon = horizon;
+
+                            action.action = "RotateLook";
+                            PhysicsController.ProcessControlCommand(action);
                         }
                     }
             }

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -6,6 +6,11 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
     public static int PHYSICS_SIMULATION_STEPS = 20;
     public int step = 0;
 
+    protected int minHorizon = -90;
+    protected int maxHorizon = 90;
+    protected float minRotation = -360f;
+    protected float maxRotation = 360f;
+
     public override void Initialize(ServerAction action) {
         base.Initialize(action);
 
@@ -27,5 +32,37 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
         }
 
         this.step++;
+    }
+
+    public override void RotateLook(ServerAction response)
+    {
+        // Need to calculate current rotation/horizon and increment by inputs given
+        float updatedRotationValue = transform.localEulerAngles.y + response.rotation.y;
+        int updatedHorizonValue = (int)m_Camera.transform.localEulerAngles.x + response.horizon;
+
+        // Check to ensure rotation value stays between -360 and 360
+        while (updatedRotationValue >= maxRotation)
+        {
+            updatedRotationValue -= maxRotation;
+        }
+
+        while (updatedRotationValue <= minRotation)
+        {
+            updatedRotationValue += maxRotation;
+        }
+
+        // Limiting where to look based on realistic expectation (for instance, a person can't turn
+        // their head 180 degrees)
+        if (updatedHorizonValue > maxHorizon || updatedHorizonValue < minHorizon)
+        {
+            Debug.Log("Value of horizon needs to be between " + minHorizon + " and " + maxHorizon +
+                ". Setting value to 0.");
+            updatedHorizonValue = 0;
+        }
+
+        ServerAction action = new ServerAction();
+        action.rotation.y = updatedRotationValue;
+        action.horizon = updatedHorizonValue;
+        base.RotateLook(action);
     }
 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1069,6 +1069,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public override void RotateLook(ServerAction response) {
+            // Need to calculate current rotation/horizon and increment by inputs given
             float updatedRotationValue = transform.localEulerAngles.y + response.rotation.y;
             int updatedHorizonValue = (int) m_Camera.transform.localEulerAngles.x + response.horizon;
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -84,11 +84,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             new Vector3(-float.PositiveInfinity, -float.PositiveInfinity, -float.PositiveInfinity)
         );
 
-        protected int minHorizon = -90;
-        protected int maxHorizon = 90;
-        protected float minRotation = -360f;
-        protected float maxRotation = 360f;
-
         //change visibility check to use this distance when looking down
         //protected float DownwardViewDistance = 2.0f;
 
@@ -1068,33 +1063,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
         }
 
-        public override void RotateLook(ServerAction response) {
-            // Need to calculate current rotation/horizon and increment by inputs given
-            float updatedRotationValue = transform.localEulerAngles.y + response.rotation.y;
-            int updatedHorizonValue = (int) m_Camera.transform.localEulerAngles.x + response.horizon;
-
-            // Check to ensure rotation value stays between -360 and 360
-            while(updatedRotationValue >= maxRotation) {
-                updatedRotationValue -= maxRotation;
-            }
-
-            while(updatedRotationValue <= minRotation) {
-                updatedRotationValue += maxRotation;
-            }
-
-            // Limiting where to look based on realistic expectation (for instance, a person can't turn
-            // their head 180 degrees)
-            if (updatedHorizonValue > maxHorizon || updatedHorizonValue < minHorizon) {
-                Debug.Log("Value of horizon needs to be between " + minHorizon + " and " + maxHorizon +
-                    ". Setting value to 0.");
-                updatedHorizonValue = 0;
-            }
-
-            ServerAction action = new ServerAction();
-            action.rotation.y = updatedRotationValue;
-            action.horizon = updatedHorizonValue;
-            base.RotateLook(action);
-        }
 
         public void RotateRightSmooth(ServerAction controlCommand) {
             if (CheckIfAgentCanTurn(90)) {


### PR DESCRIPTION
- Overriding RotateLook in order to allow for relative inputs for rotation/horizon
- Adding error handling for when an input for horizon is greater than 90 or less than -90 degrees
- Updated DebugDiscreteAgentController with debug code for RotateLook when "R" key is pressed

Associated Python API changes here: 
https://github.com/NextCenturyCorporation/MCS/pull/8