### PR TITLE
MCS-57 - Add lastActionStatus for Move Actions

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -930,6 +930,7 @@ public struct MetadataWrapper
 	public Vector3[] actionVector3sReturn;
 	public List<Vector3> visibleRange;
 	public System.Object actionReturn;
+	public string lastActionStatus;
 
 	public float currentTime;
 }

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -128,6 +128,15 @@ namespace UnityStandardAssets.Characters.FirstPerson
         private JavaScriptInterface jsInterface;
         private ServerAction currentServerAction;
 
+        protected string lastActionStatus;
+
+        public enum ActionStatus
+        {
+            SUCCESSFUL,
+            OBSTRUCTED,
+            FAILED // generic error code for unexpected failures
+        }
+
 		public Quaternion TargetRotation
 		{
 			get { return targetRotation; }
@@ -246,6 +255,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 errorMessage = "agentMode must be set to 'bot' or 'tall'";
                 Debug.Log(errorMessage);
                 actionFinished(false);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                 return;
             }
 
@@ -265,6 +275,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 				errorMessage = "fov must be set to (0, 180) noninclusive.";
                 Debug.Log(errorMessage);
                 actionFinished(false);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                 return;
 			}
 
@@ -299,6 +310,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 errorMessage = "Time scale must be >0";
                 Debug.Log(errorMessage);
                 actionFinished(false);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                 return;
             }
 
@@ -318,6 +330,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 errorMessage = "grid size must be in the range (0,5]";
                 Debug.Log(errorMessage);
                 actionFinished(false);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                 return;
             }
             else
@@ -325,6 +338,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 gridSize = action.gridSize;
                 //StartCoroutine(checkInitializeAgentLocationAction());
                 snapToGrid();
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
                 actionFinished(true);
             }
 
@@ -339,6 +353,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     errorMessage = "Invalid argument 'rotateStepDegrees': 360 should be divisible by 'rotateStepDegrees'.";
                     Debug.Log(errorMessage);
                     actionFinished(false);
+                    this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                     return;
                 }
                 else {
@@ -642,12 +657,12 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		public virtual void ProcessControlCommand(ServerAction controlCommand)
 		{
             currentServerAction = controlCommand;
-			
-	        errorMessage = "";
+			errorMessage = "";
 			errorCode = ServerActionErrorCode.Undefined;
 			collisionsInAction = new List<string>();
 
 			lastAction = controlCommand.action;
+			lastActionStatus = null;
 			lastActionSuccess = false;
 			lastPosition = new Vector3(transform.position.x, transform.position.y, transform.position.z);
 			System.Reflection.MethodInfo method = this.GetType().GetMethod(controlCommand.action);

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -65,4 +65,10 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
         action.horizon = updatedHorizonValue;
         base.RotateLook(action);
     }
+
+    public override MetadataWrapper generateMetadataWrapper() {
+        MetadataWrapper metadataWrapper = base.generateMetadataWrapper();
+        metadataWrapper.lastActionStatus = this.lastActionStatus;
+        return metadataWrapper;
+    }
 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1894,6 +1894,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         protected bool checkIfSceneBoundsContainTargetPosition(Vector3 position) {
             if (!sceneBounds.Contains(position)) {
                 errorMessage = "Scene bounds do not contain target position.";
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                 return false;
             } else {
                 return true;
@@ -1929,16 +1930,20 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 if (uniqueId != "" && maxDistanceToObject > 0.0f) {
                     if (!physicsSceneManager.UniqueIdToSimObjPhysics.ContainsKey(uniqueId)) {
                         errorMessage = "No object with ID " + uniqueId;
-                        transform.position = oldPosition; 
+                        transform.position = oldPosition;
+                        this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                         return false;
                     }
                     SimObjPhysics sop = physicsSceneManager.UniqueIdToSimObjPhysics[uniqueId];
                     if (distanceToObject(sop) > maxDistanceToObject) {
                         errorMessage = "Agent movement would bring it beyond the max distance of " + uniqueId;
                         transform.position = oldPosition;
+                        this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
                         return false;
                     }
                 }
+
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
                 return true;
             } else {
                 return false;
@@ -2499,6 +2504,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                             errorMessage = res.transform.name + " is blocking the Agent from moving " + orientation + " with " + ItemInHand.name;
                             result = false;
                             Debug.Log(errorMessage);
+                            this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
                             return result;
                         }
 
@@ -2613,6 +2619,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         int thisAgentNum = agentManager.agents.IndexOf(this);
                         int otherAgentNum = agentManager.agents.IndexOf(maybeOtherAgent);
                         errorMessage = "Agent " + otherAgentNum.ToString() + " is blocking Agent " + thisAgentNum.ToString() + " from moving " + orientation;
+                        this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
                         return false;
                     }
 
@@ -2621,6 +2628,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         int thisAgentNum = agentManager.agents.IndexOf(this);
                         errorMessage = res.transform.name + " is blocking Agent " + thisAgentNum.ToString() + " from moving " + orientation;
                         //the moment we find a result that is blocking, return false here
+                        this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
                         return false;
                     }
                 }


### PR DESCRIPTION
- Adding lastActionStatus to MetadataWrapper and BaseFPSAgentController
- Setting appropriate lastActionStatus throughout moveInDirection
- Adding generic FAILED action status for all failure cases not covered in the Preliminary Python API doc

Associated Python API changes here: https://github.com/NextCenturyCorporation/MCS/pull/10