### PR TITLE
MCS-52 MCS-74 MCS-87

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ Alternatively, if you want to build the Unity project via the command line, run 
 ## Changelog of AI2-THOR Classes
 
 - `Scripts/AgentManager`:
-  - Added the `logs` and `sceneConfig` properties to the `ServerAction` class
+  - Added properties to `ObjectMetadata`: `points`, `visibleInCamera`
+  - Added properties to `ServerAction`: `logs`, `sceneConfig`
   - Added `virtual` to functions: `Update`
-  - Changed the `physicsSceneManager` variable from `private` to `protected` so we can access it from our subclasses
+  - Changed variables or functions from `private` to `protected`: `physicsSceneManager`
 - `Scripts/BaseFPSAgentController`:
   - Added `virtual` to functions: `Initialize`, `ProcessControlCommand`
   - Removed the hard-coded camera properties in the `SetAgentMode` function
@@ -104,7 +105,7 @@ Alternatively, if you want to build the Unity project via the command line, run 
 - `Scripts/InstantiatePrefabTest`:
   - Fixed a bug in the `CheckSpawnArea` function in which the object's bounding box was not adjusted by the object's scale.
 - `Scripts/PhysicsRemoteFPSAgentController`:
-  - Changed the `physicsSceneManager` variable from `private` to `protected` so we can access it from our subclasses
+  - Changed variables or functions from `private` to `protected`: `physicsSceneManager`, `ObjectMetadataFromSimObjPhysics`
   - Added `virtual` to functions: `DropHandObject`, `PickupObject`, `PutObject`, `ResetAgentHandPosition`, `ThrowObject`
   - Commented out a block in the `PickupObject` function that checked for collisions between the held object and other objects in the scene because it caused odd behavior if you were looking at the floor.  The `Look` functions don't make this check either, and we may decide not to move the held object during `Look` actions anyway.
   - In the `PlaceHeldObject` function: ignores `PlacementRestrictions` if `ObjType` is `IgnoreType`; sets the held object's parent to null so the parent's properties (like scale) don't affect the placement validation; sets the held object's `isKinematic` property to `false` if placement is successful.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Alternatively, if you want to build the Unity project via the command line, run 
 
 - `Scripts/AgentManager`:
   - Added properties to `ObjectMetadata`: `points`, `visibleInCamera`
-  - Added properties to `ServerAction`: `logs`, `sceneConfig`
+  - Added properties to `ServerAction`: `logs`, `objectDirection`, `receptacleObjectDirection`, `sceneConfig`
   - Added `virtual` to functions: `Update`
   - Changed variables or functions from `private` to `protected`: `physicsSceneManager`
 - `Scripts/BaseFPSAgentController`:
@@ -106,7 +106,7 @@ Alternatively, if you want to build the Unity project via the command line, run 
   - Fixed a bug in the `CheckSpawnArea` function in which the object's bounding box was not adjusted by the object's scale.
 - `Scripts/PhysicsRemoteFPSAgentController`:
   - Changed variables or functions from `private` to `protected`: `physicsSceneManager`, `ObjectMetadataFromSimObjPhysics`
-  - Added `virtual` to functions: `DropHandObject`, `PickupObject`, `PutObject`, `ResetAgentHandPosition`, `ThrowObject`
+  - Added `virtual` to functions: `CloseObject`, `DropHandObject`, `OpenObject`, `PickupObject`, `PullObject`, `PushObject`, `PutObject`, `ResetAgentHandPosition`, `ThrowObject`, `ToggleObject`
   - Commented out a block in the `PickupObject` function that checked for collisions between the held object and other objects in the scene because it caused odd behavior if you were looking at the floor.  The `Look` functions don't make this check either, and we may decide not to move the held object during `Look` actions anyway.
   - In the `PlaceHeldObject` function: ignores `PlacementRestrictions` if `ObjType` is `IgnoreType`; sets the held object's parent to null so the parent's properties (like scale) don't affect the placement validation; sets the held object's `isKinematic` property to `false` if placement is successful.
 - `Scripts/PhysicsSceneManager`:

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -828,6 +828,13 @@ public class ObjectMetadata
     public bool isMoving;//true if this game object currently has a non-zero velocity
 
     public WorldSpaceBounds objectBounds;
+
+    // MCS Additions
+    public Vector3 direction;
+    public Vector3 heading;
+    public Vector3[] points;
+    public bool visibleInCamera;
+
 	public ObjectMetadata() { }
 }
 
@@ -1023,7 +1030,7 @@ public class ServerAction
 
     public bool useAgentTransform = false;
 
-    // Machine Common Sense Additions
+    // MCS Additions
     public bool logs = false;
     public MachineCommonSenseConfigScene sceneConfig;
 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1032,6 +1032,8 @@ public class ServerAction
 
     // MCS Additions
     public bool logs = false;
+    public Vector3 objectDirection;
+    public Vector3 receptacleObjectDirection;
     public MachineCommonSenseConfigScene sceneConfig;
 
     public SimObjType ReceptableSimObjType()

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -135,6 +135,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 			IS_CLOSED_COMPLETELY,
 			IS_OPENED_COMPLETELY,
 			NOT_HELD,
+            NOT_INTERACTABLE,
 			HAND_IS_FULL,
 			NOT_OBJECT,
 			NOT_RECEPTACLE,

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -14,7 +14,9 @@ namespace UnityStandardAssets.Characters.FirstPerson
         public bool forceAction = false;
         public float gridSize = 0.1f;
         public float visibilityDistance = 0.4f;
+        public Vector3 moveOrPickupObjectDirection;
         public string moveOrPickupObjectId = "";
+        public Vector3 receptacleObjectDirection;
         public string receptacleObjectId = "";
         public float rotationIncrement = 45.0f;
         public int horizonIncrement = 30;
@@ -248,6 +250,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         {
                             action.action = "OpenObject";
                             action.moveMagnitude = 1.0f;
+                            action.objectDirection = this.receptacleObjectDirection;
                             action.objectId = this.receptacleObjectId;
                             PhysicsController.ProcessControlCommand(action);
                             /*
@@ -263,6 +266,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         {
                             action.action = "CloseObject";
                             action.moveMagnitude = 1.0f;
+                            action.objectDirection = this.receptacleObjectDirection;
                             action.objectId = this.receptacleObjectId;
                             PhysicsController.ProcessControlCommand(action);
                         }
@@ -270,6 +274,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         if(Input.GetKeyDown(KeyCode.P))
                         {
                             action.action = "PickupObject";
+                            action.objectDirection = this.moveOrPickupObjectDirection;
                             action.objectId = this.moveOrPickupObjectId;
                             PhysicsController.ProcessControlCommand(action);
                         }
@@ -277,7 +282,9 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         if(Input.GetKeyDown(KeyCode.Z))
                         {
                             action.action = "PutObject";
+                            action.objectDirection = this.moveOrPickupObjectDirection;
                             action.objectId = this.moveOrPickupObjectId;
+                            action.receptacleObjectDirection = this.receptacleObjectDirection;
                             action.receptacleObjectId = this.receptacleObjectId;
                             PhysicsController.ProcessControlCommand(action);
                         }
@@ -285,6 +292,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         if(Input.GetKeyDown(KeyCode.X))
                         {
                             action.action = "DropHandObject";
+                            action.objectDirection = this.moveOrPickupObjectDirection;
                             action.objectId = this.moveOrPickupObjectId;
                             PhysicsController.ProcessControlCommand(action);
                         }
@@ -293,6 +301,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                         {
                             action.action = this.pushPullForce > 0 ? "PushObject" : "PullObject";
                             action.moveMagnitude = System.Math.Abs(this.pushPullForce);
+                            action.objectDirection = this.moveOrPickupObjectDirection;
                             action.objectId = this.moveOrPickupObjectId;
                             PhysicsController.ProcessControlCommand(action);
                         }

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -44,7 +44,7 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
             MachineCommonSenseController.MAX_DISTANCE_ACCROSS_ROOM, layerMask).ToList();
         if (hits.Count == 0) {
             this.errorMessage = "Cannot find any object on the directional vector.";
-            // TODO lastActionStatus
+            this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OBJECT);
             this.actionFinished(false);
             return previousObjectId;
         }
@@ -56,7 +56,7 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
                 .GetComponentInParent<SimObjPhysics>();
             if (simObjPhysics == null) {
                 this.errorMessage = "The closest object on the directional vector is not interactable.";
-                // TODO lastActionStatus
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
                 this.actionFinished(false);
                 return previousObjectId;
             }

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -9,7 +9,8 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
     public static float DISTANCE_HELD_OBJECT_Y = 0.15f;
     public static float DISTANCE_HELD_OBJECT_Z = 0.15f;
 
-    // The room is 5x5 so the distance from corner to corner is around 7.08.
+    // TODO MCS-95 Make the room size configurable in the scene configuration file.
+    // The room dimensions are always 5x5 so the distance from corner to corner is around 7.08.
     public static float MAX_DISTANCE_ACCROSS_ROOM = 7.08f;
 
     // The number of times to run Physics.Simulate after each action from the player.

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -246,7 +246,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         //generates object metatada based on sim object's properties
-        private ObjectMetadata ObjectMetadataFromSimObjPhysics(SimObjPhysics simObj, bool isVisible) {
+        protected virtual ObjectMetadata ObjectMetadataFromSimObjPhysics(SimObjPhysics simObj, bool isVisible) {
             ObjectMetadata objMeta = new ObjectMetadata();
             GameObject o = simObj.gameObject;
             objMeta.name = o.name;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2085,7 +2085,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
         }
 
-        public void PushObject(ServerAction action) {
+        public virtual void PushObject(ServerAction action) {
             if (ItemInHand != null && action.objectId == ItemInHand.GetComponent<SimObjPhysics>().uniqueID) {
                 errorMessage = "Please use Throw for an item in the Agent's Hand";
                 Debug.Log(errorMessage);
@@ -2102,7 +2102,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             ApplyForceObject(action);
         }
 
-        public void PullObject(ServerAction action) {
+        public virtual void PullObject(ServerAction action) {
             if (ItemInHand != null && action.objectId == ItemInHand.GetComponent<SimObjPhysics>().uniqueID) {
                 errorMessage = "Please use Throw for an item in the Agent's Hand";
                 Debug.Log(errorMessage);
@@ -4525,7 +4525,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             StartCoroutine(InteractAndWait(coos));
         }
 
-        public void CloseObject(ServerAction action) {
+        public virtual void CloseObject(ServerAction action) {
             //pass name of object in from action.objectID
             //check if that object is in the viewport
             //also check to make sure that target object is interactable
@@ -4945,7 +4945,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
 
-        public void ToggleObject(ServerAction action, bool toggleOn, bool forceAction)
+        public virtual void ToggleObject(ServerAction action, bool toggleOn, bool forceAction)
         {
             if (action.objectId == null)
             {
@@ -5063,7 +5063,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             actionFinished(success);
         }
 
-        public void OpenObject(ServerAction action) {
+        public virtual void OpenObject(ServerAction action) {
             //pass name of object in from action.objectID
             //check if that object is in the viewport
             //also check to make sure that target object is interactable


### PR DESCRIPTION
MCS-52 and MCS-74

Return new properties in the object metadata output: direction/heading from the player to the object, the array of 3D points that make the object's shape, and whether the object is visible in the camera view.

MCS-87

Accept an objectDirection/receptacleObjectDirection in the action data and use the raycaster to convert it to an objectId, if possible.