### PR TITLE
MCS-64 MCS-65

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -132,12 +132,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public enum ActionStatus
         {
+			HAND_IS_FULL,
 			IS_CLOSED_COMPLETELY,
 			IS_OPENED_COMPLETELY,
 			NOT_HELD,
             NOT_INTERACTABLE,
-			HAND_IS_FULL,
 			NOT_OBJECT,
+            NOT_OPENABLE,
 			NOT_RECEPTACLE,
 			NOT_PICKUPABLE,
 			OBSTRUCTED,
@@ -969,6 +970,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		public void Look(ServerAction response)
 		{
 			m_Camera.transform.localEulerAngles = new Vector3(response.horizon, 0.0f, 0.0f);
+            this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
 			actionFinished(true);
 		}
 
@@ -976,6 +978,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		public virtual void Rotate(ServerAction response)
 		{
 			transform.rotation = Quaternion.Euler(new Vector3(0.0f, response.rotation.y, 0.0f));
+            this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
 			actionFinished(true);
 		}
 
@@ -984,6 +987,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		{
 			transform.rotation = Quaternion.Euler(new Vector3(0.0f, response.rotation.y, 0.0f));
 			m_Camera.transform.localEulerAngles = new Vector3(response.horizon, 0.0f, 0.0f);
+            this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
 			actionFinished(true);
 
 		}
@@ -992,6 +996,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		public virtual void RotateLeft(ServerAction controlCommand)
 		{
 			transform.rotation = GetRotateQuaternion(-1);
+            this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
 			actionFinished(true);
 		}
 
@@ -1006,6 +1011,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 		public virtual void RotateRight(ServerAction controlCommand)
 		{
 			transform.rotation = transform.rotation = GetRotateQuaternion(1);
+            this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
 			actionFinished(true);
 		}
 
@@ -1016,6 +1022,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 			{
 				float targetHorizon = horizonAngles[currentHorizonAngleIndex() - 1];
 				m_Camera.transform.localEulerAngles = new Vector3(targetHorizon, 0.0f, 0.0f);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
 				actionFinished(true);
 
 			}
@@ -1024,6 +1031,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 				errorMessage = "can't LookDown below the min horizon angle";
 				Debug.Log(errorMessage);
 				errorCode = ServerActionErrorCode.LookDownCantExceedMin;
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
 				actionFinished(false);
 			}
 		}
@@ -1036,6 +1044,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 			{
 				float targetHorizon = horizonAngles[currentHorizonAngleIndex() + 1];
 				m_Camera.transform.localEulerAngles = new Vector3(targetHorizon, 0.0f, 0.0f);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
 				actionFinished(true);
 			}
 
@@ -1044,6 +1053,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 				errorMessage = "can't LookUp beyond the max horizon angle";
 				Debug.Log(errorMessage);
 				errorCode = ServerActionErrorCode.LookUpCantExceedMax;
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
 				actionFinished(false);
 			}
 		}

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -143,6 +143,18 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
         main.ChangeCurrentScene(action.sceneConfig);
     }
 
+    public void MCSCloseObject(ServerAction action) {
+        // The AI2-THOR Python library has buggy error checking specifically for the CloseObject function,
+        // so create our own function and call it from the Python API.
+        this.CloseObject(action);
+    }
+
+    public void MCSOpenObject(ServerAction action) {
+        // The AI2-THOR Python library has buggy error checking specifically for the OpenObject function,
+        // so create our own function and call it from the Python API.
+        this.OpenObject(action);
+    }
+
     protected override ObjectMetadata ObjectMetadataFromSimObjPhysics(SimObjPhysics simObj, bool isVisible) {
         ObjectMetadata objectMetadata = base.ObjectMetadataFromSimObjPhysics(simObj, isVisible);
 

--- a/unity/Assets/Scripts/MachineCommonSenseMain.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseMain.cs
@@ -502,6 +502,7 @@ public class MachineCommonSenseMain : MonoBehaviour {
 
                     ai2thorCanOpenObjectScript.Interact();
                 }
+                ai2thorCanOpenObjectScript.isOpenByPercentage = ai2thorCanOpenObjectScript.isOpen ? 1 : 0;
             }
         }
 


### PR DESCRIPTION
- Added lastActionStatus output to OpenObject and CloseObject actions.
- Fixed CanOpen_Object script to work with open and close percentages.
- Created wrapper OpenObject and CloseObject functions due to odd bugs in the Python library.
- Also added lastActionStatus output to all Rotate and Look actions, since I noticed they weren't there.