### PR TITLE
MCS-108 Unity App: Each action step will now return multiple images.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,4 +111,6 @@ unity/*_Data.tar.gz
 unity/*_Data/
 unity/Assets/Resources/MCS/Scenes/*
 unity/Assets/Resources/MCS/UnityAssetStore/*
+unity/Assets/_TerrainAutoUpgrade.meta
+unity/Assets/_TerrainAutoUpgrade/
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
 - `Scripts/AgentManager`:
   - Added properties to `ObjectMetadata`: `points`, `visibleInCamera`
   - Added properties to `ServerAction`: `logs`, `objectDirection`, `receptacleObjectDirection`, `sceneConfig`
-  - Added `virtual` to functions: `Update`
-  - Changed variables or functions from `private` to `protected`: `physicsSceneManager`
+  - Added `virtual` to functions: `setReadyToEmit`, `Update`
+  - Changed variables or functions from `private` to `protected`: `physicsSceneManager`, most `render*Image` variables
+  - Changed variables or functions from `private` to `public`: `captureScreen`, 'renderImage'
+  - Split the existing metadata-update-behavior of the `addObjectImageForm` function into a separate, new function called `UpdateMetadataColors`
+  - Created the `InitializeForm` and `FinalizeMultiAgentMetadata` virtual functions and called them both inside `EmitFrame`
+  - In `ProcessControlCommand`, changed `readyToEmit = true` to `this.setReadyToEmit(true);`
 - `Scripts/BaseFPSAgentController`:
   - Added `virtual` to functions: `Initialize`, `ProcessControlCommand`
   - Removed the hard-coded camera properties in the `SetAgentMode` function

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -23,12 +23,12 @@ public class AgentManager : MonoBehaviour
 	private Rect readPixelsRect;
 	private int currentSequenceId;
 	private int activeAgentId;
-	private bool renderImage = true;
-	private bool renderDepthImage;
-	private bool renderClassImage;
-	private bool renderObjectImage;
-	private bool renderNormalsImage;
-    private bool renderFlowImage;
+	public bool renderImage = true;
+	protected bool renderDepthImage;
+	protected bool renderClassImage;
+	protected bool renderObjectImage;
+	protected bool renderNormalsImage;
+    protected bool renderFlowImage;
 	private bool synchronousHttp = true;
 	private Socket sock = null;
 	private List<Camera> thirdPartyCameras = new List<Camera>();
@@ -284,7 +284,7 @@ public class AgentManager : MonoBehaviour
         return false;
     }
 
-	public void setReadyToEmit(bool readyToEmit) {
+	public virtual void setReadyToEmit(bool readyToEmit) {
 		this.readyToEmit = readyToEmit;
 	}
 
@@ -361,7 +361,7 @@ public class AgentManager : MonoBehaviour
 
 	}
 
-	private byte[] captureScreen() {
+	public byte[] captureScreen() {
 		if (tex.height != UnityEngine.Screen.height || 
 			tex.width != UnityEngine.Screen.width) {
 			tex = new Texture2D(UnityEngine.Screen.width, UnityEngine.Screen.height, TextureFormat.RGB24, false);
@@ -408,7 +408,12 @@ public class AgentManager : MonoBehaviour
 			}
 			byte[] bytes = agent.imageSynthesis.Encode ("_id");
 			form.AddBinaryData ("image_ids", bytes);
+            metadata = this.UpdateMetadataColors(agent, metadata);
+		}
+    }
 
+    public MetadataWrapper UpdateMetadataColors(BaseFPSAgentController agent, MetadataWrapper metadata) {
+		if (this.renderObjectImage) {
 			Color[] id_image = agent.imageSynthesis.tex.GetPixels();
 			Dictionary<Color, int[]> colorBounds = new Dictionary<Color, int[]> ();
 			for (int yy = 0; yy < tex.height; yy++) {
@@ -459,8 +464,8 @@ public class AgentManager : MonoBehaviour
 				colors.Add (cid);
 			}
 			metadata.colors = colors.ToArray ();
-
-		}
+        }
+        return metadata;
 	}
 
 	private void addImageSynthesisImageForm(WWWForm form, ImageSynthesis synth, bool flag, string captureName, string fieldName)
@@ -496,8 +501,15 @@ public class AgentManager : MonoBehaviour
 		ProcessControlCommand(msg);
 	}
 
+    protected virtual WWWForm InitializeForm(WWWForm form) {
+        return form;
+    }
 
-	public IEnumerator EmitFrame() {
+    protected virtual MultiAgentMetadata FinalizeMultiAgentMetadata(MultiAgentMetadata metadata) {
+        return metadata;
+    }
+
+	public virtual IEnumerator EmitFrame() {
 
 
 		frameCounter += 1;
@@ -510,6 +522,8 @@ public class AgentManager : MonoBehaviour
 		}
 
 		WWWForm form = new WWWForm();
+
+        form = this.InitializeForm(form);
 
         MultiAgentMetadata multiMeta = new MultiAgentMetadata ();
         multiMeta.agents = new MetadataWrapper[this.agents.Count];
@@ -561,6 +575,8 @@ public class AgentManager : MonoBehaviour
         if (shouldRender) {
             RenderTexture.active = currentTexture;
         }
+
+        multiMeta = this.FinalizeMultiAgentMetadata(multiMeta);
 
         var serializedMetadata = Newtonsoft.Json.JsonConvert.SerializeObject(multiMeta);
 		#if UNITY_WEBGL
@@ -708,7 +724,7 @@ public class AgentManager : MonoBehaviour
 			this.UpdateThirdPartyCamera(controlCommand);
 		} else {
 			this.activeAgent().ProcessControlCommand (controlCommand);
-			readyToEmit = true;
+            this.setReadyToEmit(true);
 		}
 	}
 

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -15,8 +15,9 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
     // The room dimensions are always 5x5 so the distance from corner to corner is around 7.08.
     public static float MAX_DISTANCE_ACCROSS_ROOM = 7.08f;
 
-    // The number of times to run Physics.Simulate after each action from the player.
-    public static int PHYSICS_SIMULATION_STEPS = 15;
+    // The number of times to run Physics.Simulate after each action from the player is LOOPS * STEPS.
+    public static int PHYSICS_SIMULATION_LOOPS = 5;
+    public static int PHYSICS_SIMULATION_STEPS = 3;
 
     public int step = 0;
 
@@ -126,17 +127,16 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
     }
 
     public override MetadataWrapper generateMetadataWrapper() {
-        MetadataWrapper metadataWrapper = base.generateMetadataWrapper();
-        metadataWrapper.lastActionStatus = this.lastActionStatus;
-        metadataWrapper.reachDistance = this.maxVisibleDistance;
-        return metadataWrapper;
+        MetadataWrapper metadata = base.generateMetadataWrapper();
+        metadata.lastActionStatus = this.lastActionStatus;
+        metadata.reachDistance = this.maxVisibleDistance;
+        return this.agentManager.UpdateMetadataColors(this, metadata);
     }
 
     public override void Initialize(ServerAction action) {
         base.Initialize(action);
 
-        // Set the step to -1 here because it will increase to 0 in ProcessControlCommand.
-        this.step = -1;
+        this.step = 0;
         MachineCommonSenseMain main = GameObject.Find("MCS").GetComponent<MachineCommonSenseMain>();
         main.enableVerboseLog = action.logs;
         // Reset the MCS scene configuration data and player.
@@ -215,9 +215,12 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
 
         base.ProcessControlCommand(controlCommand);
 
-        this.SimulatePhysics();
+        // Clear the saved images from the previous step.
+        ((MachineCommonSensePerformerManager)this.agentManager).ClearSavedImages();
 
-        this.step++;
+        if (!controlCommand.action.Equals("Initialize")) {
+            this.step++;
+        }
     }
 
     public override void PullObject(ServerAction action) {
@@ -327,11 +330,64 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
     }
 
     public void SimulatePhysics() {
+        // Step 0 is initialization.
+        if (this.step == 0) {
+            // After initialization, simulate the physics so that the objects can settle onto the floor.
+            this.SimulatePhysicsCompletely();
+
+            if (this.agentManager.renderImage) {
+                // We only need to save ONE image of the scene after initialization.
+                ((MachineCommonSensePerformerManager)this.agentManager).SaveImages(this.imageSynthesis);
+            }
+
+            // Notify the AgentManager to send the action output metadata and images to the Python API.
+            ((MachineCommonSensePerformerManager)this.agentManager).FinalizeEmit();
+        }
+        else {
+            if (this.agentManager.renderImage) {
+                StartCoroutine(this.SimulatePhysicsSaveImagesIncreaseStep(
+                    MachineCommonSenseController.PHYSICS_SIMULATION_LOOPS));
+            }
+            else {
+                this.SimulatePhysicsCompletely();
+                // Notify the AgentManager to send the action output metadata and images to the Python API.
+                ((MachineCommonSensePerformerManager)this.agentManager).FinalizeEmit();
+            }
+        }
+    }
+
+    private void SimulatePhysicsCompletely() {
+        for (int i = 0; i < MachineCommonSenseController.PHYSICS_SIMULATION_LOOPS; ++i) {
+            this.SimulatePhysicsOnce();
+        }
+    }
+
+    private void SimulatePhysicsOnce() {
         // Call Physics.Simulate multiple times with a small step value because a large step
         // value causes collision errors.  From the Unity Physics.Simulate documentation:
         // "Using step values greater than 0.03 is likely to produce inaccurate results."
         for (int i = 0; i < MachineCommonSenseController.PHYSICS_SIMULATION_STEPS; ++i) {
             Physics.Simulate(0.01f);
+        }
+    }
+
+    private IEnumerator SimulatePhysicsSaveImagesIncreaseStep(int thisLoop) {
+        yield return new WaitForEndOfFrame(); // Required for coroutine functions
+
+        // Run the physics simulation for a little bit, then pause and save the images for the current scene.
+        this.SimulatePhysicsOnce();
+
+        ((MachineCommonSensePerformerManager)this.agentManager).SaveImages(this.imageSynthesis);
+
+        int nextLoop = thisLoop - 1;
+
+        if (nextLoop > 0) {
+            // Continue the next loop: run the physics simulation, then save more images.
+            StartCoroutine(this.SimulatePhysicsSaveImagesIncreaseStep(nextLoop));
+        }
+        else {
+            // Once finished, notify the AgentManager to send the action output metadata and images to the Python API.
+            ((MachineCommonSensePerformerManager)this.agentManager).FinalizeEmit();
         }
     }
 

--- a/unity/Assets/Scripts/MachineCommonSenseMain.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseMain.cs
@@ -64,7 +64,7 @@ public class MachineCommonSenseMain : MonoBehaviour {
     // Unity's Update method is called once per frame
     void Update() {
         // If the player made a step, update the scene based on the current configuration.
-        if (this.lastStep < agentController.step) {
+        if (this.lastStep < this.agentController.step) {
             this.lastStep++;
             LogVerbose("Run Step " + this.lastStep + " at Frame " + Time.frameCount);
             if (this.currentScene != null && this.currentScene.objects != null) {
@@ -85,10 +85,7 @@ public class MachineCommonSenseMain : MonoBehaviour {
                         }
                     });
             }
-            if (agentController.step == 0) {
-                // After initialization, simulate the physics so that objects can settle down onto the floor.
-                agentController.SimulatePhysics();
-            }
+            this.agentController.SimulatePhysics();
         }
     }
 

--- a/unity/Assets/Scripts/MachineCommonSensePerformerManager.cs
+++ b/unity/Assets/Scripts/MachineCommonSensePerformerManager.cs
@@ -1,7 +1,98 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 public class MachineCommonSensePerformerManager : AgentManager {
+    public List<byte[]> imageList = new List<byte[]>();
+    public List<byte[]> imageClassList = new List<byte[]>();
+    public List<byte[]> imageDepthList = new List<byte[]>();
+    public List<byte[]> imageFlowList = new List<byte[]>();
+    public List<byte[]> imageNormalList = new List<byte[]>();
+    public List<byte[]> imageObjectList = new List<byte[]>();
+
+    private int imageCount = 0;
+
+    private WWWForm AddImageDataToForm(WWWForm form, List<byte[]> list, string field) {
+        list.ForEach((image) => {
+            if (image != null) {
+                form.AddBinaryData(field, image);
+            }
+        });
+        return form;
+    }
+
+    public void ClearSavedImages() {
+        this.imageCount = 0;
+        this.imageList.Clear();
+        this.imageClassList.Clear();
+        this.imageDepthList.Clear();
+        this.imageFlowList.Clear();
+        this.imageNormalList.Clear();
+        this.imageObjectList.Clear();
+    }
+
+    public override IEnumerator EmitFrame() {
+        // Set renderImage to false before calling AgentManager.EmitFrame because we've rendered all the images already
+        // and we don't want AgentManager.EmitFrame to re-render the images.
+        this.renderImage = false;
+        return base.EmitFrame();
+    }
+
+    public void FinalizeEmit() {
+        // This will notify the AgentManager to send the action output metadata and our saved images to the Python API.
+        base.setReadyToEmit(true);
+    }
+
+    protected override MultiAgentMetadata FinalizeMultiAgentMetadata(MultiAgentMetadata metadata) {
+        // Assumption: The existing metadata for any MCS use case will always have exactly one agent.
+        List<MetadataWrapper> metadataList = metadata.agents.ToList();
+        // Hack: The AI2-THOR Python API will only accept multiple images if multiple agents exist in the metadata, so
+        // pretend we have separate agents for each image that we want to send (just copy the existing agent object).
+        for (int i = 0; i < (this.imageCount - 1); ++i) {
+            metadataList.Add(metadata.agents[0]);
+        }
+        metadata.agents = metadataList.ToArray();
+        return metadata;
+    }
+
+    protected override WWWForm InitializeForm(WWWForm form) {
+        WWWForm formToReturn = base.InitializeForm(form);
+        // Add our saved images to the form that is sent to the Python API.
+        formToReturn = this.AddImageDataToForm(formToReturn, this.imageList, "image");
+        formToReturn = this.AddImageDataToForm(formToReturn, this.imageClassList, "image_classes");
+        formToReturn = this.AddImageDataToForm(formToReturn, this.imageDepthList, "image_depth");
+        formToReturn = this.AddImageDataToForm(formToReturn, this.imageFlowList, "image_flow");
+        formToReturn = this.AddImageDataToForm(formToReturn, this.imageNormalList, "image_normals");
+        formToReturn = this.AddImageDataToForm(formToReturn, this.imageObjectList, "image_ids");
+        return formToReturn;
+    }
+
+    public void SaveImages(ImageSynthesis imageSynthesis) {
+        if (this.renderImage) {
+            byte[] image = this.captureScreen();
+            this.imageList.Add(image);
+        }
+        this.SaveImageForActionOutput(imageSynthesis, this.renderClassImage, "_class", this.imageClassList);
+        this.SaveImageForActionOutput(imageSynthesis, this.renderDepthImage, "_depth", this.imageDepthList);
+        this.SaveImageForActionOutput(imageSynthesis, this.renderFlowImage, "_flow", this.imageFlowList);
+        this.SaveImageForActionOutput(imageSynthesis, this.renderNormalsImage, "_normals", this.imageNormalList);
+        this.SaveImageForActionOutput(imageSynthesis, this.renderObjectImage, "_id", this.imageObjectList);
+        this.imageCount++;
+    }
+
+    private void SaveImageForActionOutput(ImageSynthesis imageSynthesis, bool flag, string type, List<byte[]> list) {
+        if (flag && imageSynthesis.hasCapturePass(type)) {
+            byte[] image = imageSynthesis.Encode(type);
+            list.Add(image);
+        }
+    }
+
+	public override void setReadyToEmit(bool readyToEmit) {
+        // Don't set readyToEmit yet because we don't want the AgentManager to send the action output metadata and our
+        // saved images to the Python API until AFTER we've rendered and saved all the images (and call FinalizeEmit)!
+    }
+
     public override void Update() {
         base.Update();
         // Our scene is never at rest (it is always moving)!


### PR DESCRIPTION
Used with Python branch MCS-108 (PR: https://github.com/NextCenturyCorporation/MCS/pull/35)

Previously, physics was simulated (unpaused, then paused again) in the MCS scripts, then images were recorded in AgentManager.EmitFrame, saved as byte arrays to the WWWForm, and sent to the Python API.

Now, physics is simulated in 5 smaller "loops", and images are recorded after each individual loop, snapshoting objects moving slowly as they are affected by the physics simulation.  This should fix the "jerkiness" issue.  Images are no longer recorded in AgentManager.EmitFrame.

To do this without modifying the AI2-THOR Python API itself, I'm hijacking the existing MultiAgentMetadata object.  We're pretending to have multiple agents and using each agent's image output to return one of the images from each of the 5 loops.

Note that recording each image must be done in its own coroutine (waiting for the end of the current frame), which causes some slowness.  I had to override setReadyToEmit to ensure that the AgentManager waited until we were finished looping through coroutines and recording all images.