### PR TITLE
MCS-160 Material Restrictions

### DIFF
--- a/unity/Assets/Resources/MCS/ai2thor_object_registry.json
+++ b/unity/Assets/Resources/MCS/ai2thor_object_registry.json
@@ -3,16 +3,19 @@
         "id": "apple_1",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Apple/Prefabs/Apple_1",
         "mass": 0.25,
+        "materialRestrictions": ["no_material"],
         "pickupable": true
     }, {
         "id": "apple_2",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Apple/Prefabs/Apple_2",
         "mass": 0.25,
+        "materialRestrictions": ["no_material"],
         "pickupable": true
     }, {
         "id": "box_2",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room and Bedroom Objects/Box_Full/Prefabs/Box_2",
         "mass": 0.5,
+        "materialRestrictions": ["no_material"],
         "openable": true,
         "pickupable": true,
         "receptacle": true
@@ -20,6 +23,7 @@
         "id": "box_3",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room and Bedroom Objects/Box_Full/Prefabs/Box_3",
         "mass": 0.5,
+        "materialRestrictions": ["no_material"],
         "openable": true,
         "pickupable": true,
         "receptacle": true
@@ -27,18 +31,21 @@
         "id": "bowl_3",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Bowl/Prefabs/Bowl_3",
         "mass": 0.25,
+        "materialRestrictions": ["plastic"],
         "pickupable": true,
         "receptacle": true
     }, {
         "id": "bowl_4",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Bowl/Prefabs/Bowl_4",
         "mass": 0.25,
+        "materialRestrictions": ["plastic"],
         "pickupable": true,
         "receptacle": true
     }, {
         "id": "chair_1",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/Furniture/ChairWood",
         "mass": 2,
+        "materialRestrictions": ["wood"],
         "salientMaterials": ["wood"],
         "moveable": true,
         "boundingBox": {
@@ -57,6 +64,7 @@
         "id": "chair_2",
         "resourceFile": "AI2-THOR/Objects/Prefabs/SimObjs/UNFINISHED/Furniture/Chair2",
         "mass": 1,
+        "materialRestrictions": ["plastic"],
         "salientMaterials": ["plastic"],
         "moveable": true,
         "boundingBox": {
@@ -193,18 +201,21 @@
         "id": "cup_2",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Cup/Prefabs/Cup_2",
         "mass": 0.25,
+        "materialRestrictions": ["plastic"],
         "pickupable": true,
         "receptacle": true
     }, {
         "id": "cup_6",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Cup/Prefabs/Cup_6",
         "mass": 0.25,
+        "materialRestrictions": ["plastic"],
         "pickupable": true,
         "receptacle": true
     }, {
         "id": "plate_1",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Plate/Prefabs/Plate_1",
         "mass": 0.25,
+        "materialRestrictions": ["plastic"],
         "salientMaterials": ["plastic"],
         "pickupable": true,
         "receptacle": true
@@ -212,49 +223,63 @@
         "id": "plate_3",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Kitchen Objects/Plate/Prefabs/Plate_3",
         "mass": 0.25,
+        "materialRestrictions": ["plastic"],
         "salientMaterials": ["plastic"],
         "pickupable": true,
         "receptacle": true
     }, {
         "id": "painting_2",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting2"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting2",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "painting_4",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting4"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting4",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "painting_5",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting5"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting5",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "painting_9",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting9"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting9",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "painting_10",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting10"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting10",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "painting_16",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting16"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/WallDecorations/Paintings/WallPainting16",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "plant_1",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_1"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_1",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "plant_5",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_5"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_5",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "plant_7",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_7"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_7",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "plant_9",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_9"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_9",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "plant_14",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_14"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_14",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "plant_16",
-        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_16"
+        "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Living Room Objects/HousePlant/Prefabs/Houseplant_16",
+        "materialRestrictions": ["no_material"]
     }, {
         "id": "shelf_1",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/THORKEA Objects/THORKEA_Assets_Furniture/ShelvingUnit/Prefabs/thorkea_shelving_unit_kallax_small_2_v",
         "mass": 10,
+        "materialRestrictions": ["wood"],
         "salientMaterials": ["wood"],
         "kinematic": true,
         "receptacle": true,
@@ -274,6 +299,7 @@
         "id": "sofa_1",
         "resourceFile": "AI2-THOR/Objects/Prefabs/StaticObjects/Furniture/Sofas/Sofa",
         "mass": 100,
+        "materialRestrictions": ["no_material"],
         "salientMaterials": ["fabric"],
         "kinematic": true,
         "physics": true,
@@ -478,6 +504,7 @@
         "id": "sofa_chair_1",
         "resourceFile": "AI2-THOR/Objects/Prefabs/StaticObjects/Furniture/Sofas/SofaChair1",
         "mass": 50,
+        "materialRestrictions": ["no_material"],
         "salientMaterials": ["fabric"],
         "kinematic": true,
         "physics": true,
@@ -594,6 +621,7 @@
         "id": "table_1",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Custom Project Objects/Hide And Seek Objects/Tables/Long Table 2",
         "mass": 10,
+        "materialRestrictions": ["metal"],
         "salientMaterials": ["metal"],
         "materials": ["WhiteMetal", "BrushedIron_AlbedoTransparency", "BlackFoil"],
         "kinematic": true,
@@ -614,6 +642,7 @@
         "id": "table_5",
         "resourceFile": "AI2-THOR/Objects/Prefabs/StaticObjects/Furniture/Tables/TVTable",
         "mass": 20,
+        "materialRestrictions": ["wood"],
         "salientMaterials": ["wood"],
         "materials": ["LightWoodCounters3", "DarkWoodSmooth2"],
         "kinematic": true,
@@ -712,6 +741,7 @@
         "id": "table_6",
         "resourceFile": "AI2-THOR/Objects/Physics/SimObjsPhysics/Entryway Objects/Furniture/FlatTable",
         "mass": 20,
+        "materialRestrictions": ["wood"],
         "salientMaterials": ["wood"],
         "materials": [],
         "kinematic": true,

--- a/unity/Assets/Resources/MCS/material_registry.json
+++ b/unity/Assets/Resources/MCS/material_registry.json
@@ -1,17 +1,35 @@
 {
-    "materials": [
+    "block_blank": [
+        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1",
+        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/red_1x1",
+        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/wood_1x1",
+        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/yellow_1x1"
+    ],
+    "block_design": [
+        "UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_C_Blue_1K/ToyBlockBlueC",
+        "UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_M_Blue_1K/ToyBlockBlueM",
+        "UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_S_Blue_1K/ToyBlockBlueS",
+        "UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_1_Yellow_1K/NumberBlockYellow_1",
+        "UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_2_Yellow_1K/NumberBlockYellow_2",
+        "UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_3_Yellow_1K/NumberBlockYellow_3"
+    ],
+    "ceramic": [
         "AI2-THOR/Materials/Ceramics/BrownMarbleFake 1",
         "AI2-THOR/Materials/Ceramics/ConcreteBoards1",
         "AI2-THOR/Materials/Ceramics/GREYGRANITE",
         "AI2-THOR/Materials/Ceramics/RedBrick",
         "AI2-THOR/Materials/Ceramics/TexturesCom_BrickRound0044_1_seamless_S",
-        "AI2-THOR/Materials/Ceramics/WhiteCountertop",
+        "AI2-THOR/Materials/Ceramics/WhiteCountertop"
+    ],
+    "fabric": [
         "AI2-THOR/Materials/Fabrics/Carpet2",
         "AI2-THOR/Materials/Fabrics/Carpet4",
         "AI2-THOR/Materials/Fabrics/CarpetDark",
         "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
         "AI2-THOR/Materials/Fabrics/HotelCarpet3",
-        "AI2-THOR/Materials/Fabrics/RugPattern224",
+        "AI2-THOR/Materials/Fabrics/RugPattern224"
+    ],
+    "metal": [
         "AI2-THOR/Materials/Metals/BlackSmoothMeta",
         "AI2-THOR/Materials/Metals/Brass 1",
         "AI2-THOR/Materials/Metals/BrownMetal 1",
@@ -20,15 +38,21 @@
         "AI2-THOR/Materials/Metals/WhiteMetal",
         "AI2-THOR/Materials/Metals/Metal",
         "AI2-THOR/Materials/Metals/WhiteMetal",
-        "UnityAssetStore/Baby_Room/Models/Materials/cabinet metal",
+        "UnityAssetStore/Baby_Room/Models/Materials/cabinet metal"
+    ],
+    "plastic": [
         "AI2-THOR/Materials/Plastics/BlackPlastic",
         "AI2-THOR/Materials/Plastics/OrangePlastic",
         "AI2-THOR/Materials/Plastics/WhitePlastic",
         "UnityAssetStore/Kindergarten_Interior/Models/Materials/color 1",
         "UnityAssetStore/Kindergarten_Interior/Models/Materials/color 2",
-        "UnityAssetStore/Kindergarten_Interior/Models/Materials/color 4",
+        "UnityAssetStore/Kindergarten_Interior/Models/Materials/color 4"
+    ],
+    "rubber": [
         "AI2-THOR/Materials/Plastics/BlueRubber",
-        "AI2-THOR/Materials/Plastics/LightBlueRubber",
+        "AI2-THOR/Materials/Plastics/LightBlueRubber"
+    ],
+    "wall": [
         "AI2-THOR/Materials/Walls/Drywall",
         "AI2-THOR/Materials/Walls/DrywallBeige",
         "AI2-THOR/Materials/Walls/DrywallOrange",
@@ -36,7 +60,9 @@
         "AI2-THOR/Materials/Walls/EggshellDrywall",
         "AI2-THOR/Materials/Walls/RedDrywall",
         "AI2-THOR/Materials/Walls/WallDrywallGrey",
-        "AI2-THOR/Materials/Walls/YellowDrywall",
+        "AI2-THOR/Materials/Walls/YellowDrywall"
+    ],
+    "wood": [
         "AI2-THOR/Materials/Wood/BedroomFloor1",
         "AI2-THOR/Materials/Wood/DarkWood2",
         "AI2-THOR/Materials/Wood/DarkWoodSmooth2",
@@ -50,16 +76,6 @@
         "UnityAssetStore/Baby_Room/Models/Materials/wood 1",
         "UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 1",
         "UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 2",
-        "UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 4",
-        "UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_1_Yellow_1K/NumberBlockYellow_1",
-        "UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_2_Yellow_1K/NumberBlockYellow_2",
-        "UnityAssetStore/KD_NumberBlocks/Assets/Textures/Yellow/TOYBlocks_NumberBlock_3_Yellow_1K/NumberBlockYellow_3",
-        "UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_C_Blue_1K/ToyBlockBlueC",
-        "UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_M_Blue_1K/ToyBlockBlueM",
-        "UnityAssetStore/KD_AlphabetBlocks/Assets/Textures/Blue/TOYBlocks_AlphabetBlock_S_Blue_1K/ToyBlockBlueS",
-        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/blue_1x1",
-        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/red_1x1",
-        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/wood_1x1",
-        "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/meshes/Materials/yellow_1x1"
+        "UnityAssetStore/Kindergarten_Interior/Models/Materials/color wood 4"
     ]
 }

--- a/unity/Assets/Resources/MCS/mcs_object_registry.json
+++ b/unity/Assets/Resources/MCS/mcs_object_registry.json
@@ -3,6 +3,7 @@
         "id": "block_blank_blue_cube",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cubes/cube_1x1_blue",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {
@@ -78,6 +79,7 @@
         "id": "block_blank_red_cube",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cubes/cube_1x1_red",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {
@@ -153,9 +155,9 @@
         "id": "block_blank_wood_cube",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cubes/cube_1x1",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
-        "salientMaterials": ["wood"],
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -229,6 +231,7 @@
         "id": "block_blank_yellow_cube",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cubes/cube_1x1_yellow",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {
@@ -304,6 +307,7 @@
         "id": "block_blank_blue_cylinder",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cylinders/cylinder_1x1_blue",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {
@@ -379,6 +383,7 @@
         "id": "block_blank_red_cylinder",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cylinders/cylinder_1x1_red",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {
@@ -454,9 +459,9 @@
         "id": "block_blank_wood_cylinder",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cylinders/cylinder_1x1",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
-        "salientMaterials": ["wood"],
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -530,6 +535,7 @@
         "id": "block_blank_yellow_cylinder",
         "resourceFile": "UnityAssetStore/Wooden_Toys_Bundle/ToyBlocks/prefabs/cylinders/cylinder_1x1_yellow",
         "mass": 0.66,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {
@@ -605,6 +611,7 @@
         "id": "block_blue_letter_c",
         "resourceFile": "UnityAssetStore/KD_AlphabetBlocks/Assets/Prefabs/Blue/TOYBlock_Blue_C_LP",
         "mass": 0.66,
+        "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "scale": {
@@ -698,6 +705,7 @@
         "id": "block_blue_letter_m",
         "resourceFile": "UnityAssetStore/KD_AlphabetBlocks/Assets/Prefabs/Blue/TOYBlock_Blue_M_LP",
         "mass": 0.66,
+        "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "scale": {
@@ -791,6 +799,7 @@
         "id": "block_blue_letter_s",
         "resourceFile": "UnityAssetStore/KD_AlphabetBlocks/Assets/Prefabs/Blue/TOYBlock_Blue_S_LP",
         "mass": 0.66,
+        "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "scale": {
@@ -884,6 +893,7 @@
         "id": "block_yellow_number_1",
         "resourceFile": "UnityAssetStore/KD_NumberBlocks/Assets/Prefabs/Yellow/TOYBlock_Yellow_1",
         "mass": 0.66,
+        "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "scale": {
@@ -964,6 +974,7 @@
         "id": "block_yellow_number_2",
         "resourceFile": "UnityAssetStore/KD_NumberBlocks/Assets/Prefabs/Yellow/TOYBlock_Yellow_2",
         "mass": 0.66,
+        "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "scale": {
@@ -1044,6 +1055,7 @@
         "id": "block_yellow_number_3",
         "resourceFile": "UnityAssetStore/KD_NumberBlocks/Assets/Prefabs/Yellow/TOYBlock_Yellow_3",
         "mass": 0.66,
+        "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "scale": {
@@ -1124,6 +1136,7 @@
         "id": "changing_table",
         "resourceFile": "UnityAssetStore/Custom/ChangingTable",
         "mass": 100,
+        "materialRestrictions": ["wood"],
         "materials": ["wood 1", "cabinet metal"],
         "salientMaterials": ["wood"],
         "kinematic": true,
@@ -1148,6 +1161,7 @@
         "id": "crayon_blue",
         "resourceFile": "UnityAssetStore/PBR_Toys_pack/Prefabs/crayon_blue",
         "mass": 0.125,
+        "materialRestrictions": ["no_material"],
         "salientMaterials": ["wax"],
         "pickupable": true,
         "scale": {
@@ -1201,6 +1215,7 @@
         "id": "crib",
         "resourceFile": "UnityAssetStore/Custom/Crib",
         "mass": 25,
+        "materialRestrictions": ["wood"],
         "materials": ["wood 1", "mattress fabric"],
         "salientMaterials": ["wood"],
         "kinematic": true,
@@ -1382,6 +1397,7 @@
         "id": "duck_on_wheels",
         "resourceFile": "UnityAssetStore/Baby_Room/Prefabs/Toy 2",
         "mass": 0.5,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {
@@ -1433,18 +1449,21 @@
         "id": "foam_floor_tiles",
         "resourceFile": "UnityAssetStore/Kindergarten_Interior/Prefabs/childrens floor",
         "mass": 1,
+        "materialRestrictions": ["no_material"],
         "salientMaterials": ["plastic"],
         "kinematic": true
     }, {
         "id": "pacifier",
         "resourceFile": "UnityAssetStore/Custom/Pacifier",
         "mass": 0.125,
+        "materialRestrictions": ["no_material"],
         "salientMaterials": ["plastic"],
         "pickupable": true
     }, {
         "id": "racecar_red",
         "resourceFile": "UnityAssetStore/Toys_Collection/Prefabs/Car 3",
         "mass": 0.5,
+        "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
         "boundingBox": {


### PR DESCRIPTION
Restrict the types of materials that may be configured on objects of specific types in the MCS scenes.