### PR TITLE
MCS-191 All colliders now in SimObjVisible layer.

### DIFF
--- a/unity/Assets/Scripts/MachineCommonSenseMain.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseMain.cs
@@ -325,6 +325,13 @@ public class MachineCommonSenseMain : MonoBehaviour {
                 return collider;
             }).ToArray();
         }
+        else {
+            // Else, add the AI2-THOR layer and tag to the existing colliders so they work with the AI2-THOR scripts.
+            colliders.ToList().ForEach((collider) => {
+                collider.gameObject.layer = 8; // AI2-THOR Layer SimObjVisible
+                collider.gameObject.tag = "SimObjPhysics"; // AI2-THOR Tag
+            });
+        }
 
         return colliders;
     }


### PR DESCRIPTION
Fixes the issue that Rajesh found with blocks and other objects not being properly marked as "visible" in the object output metadata.