### PR TITLE
MCS-217 Return Structural Object Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
 ## Changelog of AI2-THOR Classes
 
 - `Scripts/AgentManager`:
+  - Added properties to `MetadataWrapper`: `structuralObjects`
   - Added properties to `ObjectMetadata`: `points`, `visibleInCamera`
   - Added properties to `ServerAction`: `logs`, `objectDirection`, `receptacleObjectDirection`, `sceneConfig`
   - Added `virtual` to functions: `setReadyToEmit`, `Update`

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2143,6 +2143,8 @@ GameObject:
   - component: {fileID: 1057749062}
   - component: {fileID: 1057749061}
   - component: {fileID: 1057749064}
+  - component: {fileID: 1057749065}
+  - component: {fileID: 1057749066}
   m_Layer: 8
   m_Name: Floor
   m_TagString: Structure
@@ -2159,7 +2161,7 @@ Transform:
   m_GameObject: {fileID: 1057749059}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -0.5, z: 0}
-  m_LocalScale: {x: 15, y: 1, z: 12}
+  m_LocalScale: {x: 10, y: 1, z: 10}
   m_Children: []
   m_Father: {fileID: 1945212740}
   m_RootOrder: 4
@@ -2235,6 +2237,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WhatIsMyStructureObjectTag: 2
+--- !u!114 &1057749065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057749059}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniqueID: floor
+  Type: 0
+  PrimaryProperty: 1
+  SecondaryProperties: 
+  BoundingBox: {fileID: 1057749059}
+  VisibilityPoints: []
+  ReceptacleTriggerBoxes: []
+  isVisible: 0
+  isInteractable: 0
+  isInAgentHand: 0
+  MyColliders:
+  - {fileID: 1057749061}
+  HFdynamicfriction: 0
+  HFstaticfriction: 0
+  HFbounciness: 0
+  HFrbdrag: 0
+  HFrbangulardrag: 0
+  salientMaterials: 
+  CurrentTemperature: 0
+  HowManySecondsUntilRoomTemp: 10
+  inMotion: 0
+  lastVelocity: 0
+  ContainedObjectReferences: []
+--- !u!54 &1057749066
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057749059}
+  serializedVersion: 2
+  m_Mass: 1000
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1068440752 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1577045921580366, guid: 5e9e851c0e142814dac026a256ba2ac0,
@@ -2442,6 +2495,8 @@ GameObject:
   - component: {fileID: 1381832267}
   - component: {fileID: 1381832266}
   - component: {fileID: 1381832269}
+  - component: {fileID: 1381832270}
+  - component: {fileID: 1381832271}
   m_Layer: 8
   m_Name: Wall Right
   m_TagString: Structure
@@ -2458,7 +2513,7 @@ Transform:
   m_GameObject: {fileID: 1381832264}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 5.5, y: 1.5, z: 0}
-  m_LocalScale: {x: 1, y: 3, z: 12}
+  m_LocalScale: {x: 1, y: 3, z: 10}
   m_Children: []
   m_Father: {fileID: 1945212740}
   m_RootOrder: 0
@@ -2534,6 +2589,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WhatIsMyStructureObjectTag: 1
+--- !u!114 &1381832270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381832264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniqueID: wall_right
+  Type: 0
+  PrimaryProperty: 1
+  SecondaryProperties: 
+  BoundingBox: {fileID: 1381832264}
+  VisibilityPoints: []
+  ReceptacleTriggerBoxes: []
+  isVisible: 0
+  isInteractable: 0
+  isInAgentHand: 0
+  MyColliders:
+  - {fileID: 1381832266}
+  HFdynamicfriction: 0
+  HFstaticfriction: 0
+  HFbounciness: 0
+  HFrbdrag: 0
+  HFrbangulardrag: 0
+  salientMaterials: 
+  CurrentTemperature: 0
+  HowManySecondsUntilRoomTemp: 10
+  inMotion: 0
+  lastVelocity: 0
+  ContainedObjectReferences: []
+--- !u!54 &1381832271
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1381832264}
+  serializedVersion: 2
+  m_Mass: 1000
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1460899622 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1307686997440558, guid: 5e9e851c0e142814dac026a256ba2ac0,
@@ -2553,6 +2659,8 @@ GameObject:
   - component: {fileID: 1491039904}
   - component: {fileID: 1491039903}
   - component: {fileID: 1491039906}
+  - component: {fileID: 1491039907}
+  - component: {fileID: 1491039908}
   m_Layer: 8
   m_Name: Wall Back
   m_TagString: Structure
@@ -2569,7 +2677,7 @@ Transform:
   m_GameObject: {fileID: 1491039901}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 1.5, z: -5.5}
-  m_LocalScale: {x: 12, y: 3, z: 1}
+  m_LocalScale: {x: 10, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1945212740}
   m_RootOrder: 3
@@ -2645,6 +2753,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WhatIsMyStructureObjectTag: 1
+--- !u!114 &1491039907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491039901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniqueID: wall_back
+  Type: 0
+  PrimaryProperty: 1
+  SecondaryProperties: 
+  BoundingBox: {fileID: 1491039901}
+  VisibilityPoints: []
+  ReceptacleTriggerBoxes: []
+  isVisible: 0
+  isInteractable: 0
+  isInAgentHand: 0
+  MyColliders:
+  - {fileID: 1491039903}
+  HFdynamicfriction: 0
+  HFstaticfriction: 0
+  HFbounciness: 0
+  HFrbdrag: 0
+  HFrbangulardrag: 0
+  salientMaterials: 
+  CurrentTemperature: 0
+  HowManySecondsUntilRoomTemp: 10
+  inMotion: 0
+  lastVelocity: 0
+  ContainedObjectReferences: []
+--- !u!54 &1491039908
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491039901}
+  serializedVersion: 2
+  m_Mass: 1000
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1504188944
 GameObject:
   m_ObjectHideFlags: 0
@@ -2658,6 +2817,8 @@ GameObject:
   - component: {fileID: 1504188947}
   - component: {fileID: 1504188946}
   - component: {fileID: 1504188949}
+  - component: {fileID: 1504188950}
+  - component: {fileID: 1504188951}
   m_Layer: 8
   m_Name: Ceiling
   m_TagString: Structure
@@ -2674,7 +2835,7 @@ Transform:
   m_GameObject: {fileID: 1504188944}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 3.5, z: 0}
-  m_LocalScale: {x: 12, y: 1, z: 12}
+  m_LocalScale: {x: 10, y: 1, z: 10}
   m_Children: []
   m_Father: {fileID: 1945212740}
   m_RootOrder: 5
@@ -2750,6 +2911,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WhatIsMyStructureObjectTag: 3
+--- !u!114 &1504188950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1504188944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniqueID: ceiling
+  Type: 0
+  PrimaryProperty: 1
+  SecondaryProperties: 
+  BoundingBox: {fileID: 1504188944}
+  VisibilityPoints: []
+  ReceptacleTriggerBoxes: []
+  isVisible: 0
+  isInteractable: 0
+  isInAgentHand: 0
+  MyColliders:
+  - {fileID: 1504188946}
+  HFdynamicfriction: 0
+  HFstaticfriction: 0
+  HFbounciness: 0
+  HFrbdrag: 0
+  HFrbangulardrag: 0
+  salientMaterials: 
+  CurrentTemperature: 0
+  HowManySecondsUntilRoomTemp: 10
+  inMotion: 0
+  lastVelocity: 0
+  ContainedObjectReferences: []
+--- !u!54 &1504188951
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1504188944}
+  serializedVersion: 2
+  m_Mass: 1000
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1524469442 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1338297802647844, guid: 5e9e851c0e142814dac026a256ba2ac0,
@@ -2977,6 +3189,8 @@ GameObject:
   - component: {fileID: 1841293345}
   - component: {fileID: 1841293344}
   - component: {fileID: 1841293347}
+  - component: {fileID: 1841293348}
+  - component: {fileID: 1841293349}
   m_Layer: 8
   m_Name: Wall Front
   m_TagString: Structure
@@ -2992,8 +3206,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1841293342}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 2.25, z: 5.5}
-  m_LocalScale: {x: 15, y: 4.5, z: 1}
+  m_LocalPosition: {x: 0, y: 1.5, z: 5.5}
+  m_LocalScale: {x: 10, y: 3, z: 1}
   m_Children: []
   m_Father: {fileID: 1945212740}
   m_RootOrder: 2
@@ -3069,6 +3283,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WhatIsMyStructureObjectTag: 1
+--- !u!114 &1841293348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841293342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniqueID: wall_front
+  Type: 0
+  PrimaryProperty: 1
+  SecondaryProperties: 
+  BoundingBox: {fileID: 1841293342}
+  VisibilityPoints: []
+  ReceptacleTriggerBoxes: []
+  isVisible: 0
+  isInteractable: 0
+  isInAgentHand: 0
+  MyColliders:
+  - {fileID: 1841293344}
+  HFdynamicfriction: 0
+  HFstaticfriction: 0
+  HFbounciness: 0
+  HFrbdrag: 0
+  HFrbangulardrag: 0
+  salientMaterials: 
+  CurrentTemperature: 0
+  HowManySecondsUntilRoomTemp: 10
+  inMotion: 0
+  lastVelocity: 0
+  ContainedObjectReferences: []
+--- !u!54 &1841293349
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841293342}
+  serializedVersion: 2
+  m_Mass: 1000
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1891392283
 GameObject:
   m_ObjectHideFlags: 0
@@ -3182,6 +3447,8 @@ GameObject:
   - component: {fileID: 2065516559}
   - component: {fileID: 2065516558}
   - component: {fileID: 2065516561}
+  - component: {fileID: 2065516562}
+  - component: {fileID: 2065516563}
   m_Layer: 8
   m_Name: Wall Left
   m_TagString: Structure
@@ -3198,7 +3465,7 @@ Transform:
   m_GameObject: {fileID: 2065516556}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -5.5, y: 1.5, z: 0}
-  m_LocalScale: {x: 1, y: 3, z: 12}
+  m_LocalScale: {x: 1, y: 3, z: 10}
   m_Children: []
   m_Father: {fileID: 1945212740}
   m_RootOrder: 1
@@ -3274,6 +3541,57 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WhatIsMyStructureObjectTag: 1
+--- !u!114 &2065516562
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2065516556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b439f6e4ef5714ee2a3643acf37b7a9d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  uniqueID: wall_left
+  Type: 0
+  PrimaryProperty: 1
+  SecondaryProperties: 
+  BoundingBox: {fileID: 2065516556}
+  VisibilityPoints: []
+  ReceptacleTriggerBoxes: []
+  isVisible: 0
+  isInteractable: 0
+  isInAgentHand: 0
+  MyColliders:
+  - {fileID: 2065516558}
+  HFdynamicfriction: 0
+  HFstaticfriction: 0
+  HFbounciness: 0
+  HFrbdrag: 0
+  HFrbangulardrag: 0
+  salientMaterials: 
+  CurrentTemperature: 0
+  HowManySecondsUntilRoomTemp: 10
+  inMotion: 0
+  lastVelocity: 0
+  ContainedObjectReferences: []
+--- !u!54 &2065516563
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2065516556}
+  serializedVersion: 2
+  m_Mass: 1000
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &2079819806 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1586169677395318, guid: 5e9e851c0e142814dac026a256ba2ac0,

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -915,6 +915,7 @@ public class ObjectToggle
 public struct MetadataWrapper
 {
 	public ObjectMetadata[] objects;
+	public ObjectMetadata[] structuralObjects;
     public bool isSceneAtRest;//set true if all objects in the scene are at rest (or very very close to 0 velocity)
 	public ObjectMetadata agent;
 	public HandMetadata hand;

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -131,6 +131,10 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
         MetadataWrapper metadata = base.generateMetadataWrapper();
         metadata.lastActionStatus = this.lastActionStatus;
         metadata.reachDistance = this.maxVisibleDistance;
+        metadata.structuralObjects = metadata.objects.ToList().Where(objectMetadata =>
+            GameObject.Find(objectMetadata.name).GetComponent<StructureObject>() != null).ToArray();
+        metadata.objects = metadata.objects.ToList().Where(objectMetadata =>
+            GameObject.Find(objectMetadata.name).GetComponent<StructureObject>() == null).ToArray();
         return this.agentManager.UpdateMetadataColors(this, metadata);
     }
 
@@ -185,23 +189,7 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
         // Each SimObjPhysics object should have a MeshFilter component.
         MeshFilter meshFilter = simObj.gameObject.GetComponentInChildren<MeshFilter>();
 
-        // Use the object's renderer (each object should have a renderer, except maybe shelf children in complex
-        // receptacle objects) for its position because its transform's position may not be its actual position
-        // in the camera since the renderer may be defined in a child object with an offset position.
-        Renderer renderer = simObj.gameObject.GetComponentInChildren<Renderer>();
-        if (renderer != null) {
-            objectMetadata.position = renderer.bounds.center;
-            // Use the object's new position for the distance previously set in generateObjectMetadata.
-            objectMetadata.distance = Vector3.Distance(this.transform.position, objectMetadata.position);
-        }
-
-        // From https://docs.unity3d.com/Manual/DirectionDistanceFromOneObjectToAnother.html
-        objectMetadata.heading = objectMetadata.position - this.transform.position;
-        objectMetadata.direction = (objectMetadata.heading / objectMetadata.heading.magnitude);
-
-        // Calculate a distance with only the X and Z coordinates for our Python API.
-        objectMetadata.distanceXZ = Vector3.Distance(new Vector3(this.transform.position.x, 0, this.transform.position.z),
-            new Vector3(simObj.transform.position.x, 0, simObj.transform.position.z));
+        objectMetadata = this.UpdatePositionDistanceAndDirectionInObjectMetadata(simObj.gameObject, objectMetadata);
 
         if (objectMetadata.objectBounds == null && simObj.BoundingBox != null) {
             objectMetadata.objectBounds = this.WorldCoordinatesOfBoundingBox(simObj);
@@ -519,6 +507,28 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
         }
         // If we haven't yet called actionFinished then actionComplete will be false; continue the action.
         return !this.actionComplete;
+    }
+
+    private ObjectMetadata UpdatePositionDistanceAndDirectionInObjectMetadata(GameObject gameObject, ObjectMetadata objectMetadata) {
+        // Use the object's renderer (each object should have a renderer, except maybe shelf children in complex
+        // receptacle objects) for its position because its transform's position may not be its actual position
+        // in the camera since the renderer may be defined in a child object with an offset position.
+        Renderer renderer = gameObject.GetComponentInChildren<Renderer>();
+        if (renderer != null) {
+            objectMetadata.position = renderer.bounds.center;
+            // Use the object's new position for the distance previously set in generateObjectMetadata.
+            objectMetadata.distance = Vector3.Distance(this.transform.position, objectMetadata.position);
+        }
+
+        // From https://docs.unity3d.com/Manual/DirectionDistanceFromOneObjectToAnother.html
+        objectMetadata.heading = objectMetadata.position - this.transform.position;
+        objectMetadata.direction = (objectMetadata.heading / objectMetadata.heading.magnitude);
+
+        // Calculate a distance with only the X and Z coordinates for our Python API.
+        objectMetadata.distanceXZ = Vector3.Distance(new Vector3(this.transform.position.x, 0, this.transform.position.z),
+            new Vector3(gameObject.transform.position.x, 0, gameObject.transform.position.z));
+
+        return objectMetadata;
     }
 
     private void UpdateHandPositionToHoldObject(SimObjPhysics target) {

--- a/unity/Assets/Scripts/MachineCommonSenseMain.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseMain.cs
@@ -7,16 +7,29 @@ using UnityStandardAssets.Characters.FirstPerson;
 using System.Text;
 
 public class MachineCommonSenseMain : MonoBehaviour {
+    private static float CUBE_INTERNAL_GRID = 0.25f;
     private static float LIGHT_RANGE = 20f;
     private static float LIGHT_RANGE_SCREENSHOT = 10f;
     private static float LIGHT_Y_POSITION = 2.95f;
     private static float LIGHT_Y_POSITION_SCREENSHOT = 0.5f;
     private static float LIGHT_Z_POSITION = 0;
     private static float LIGHT_Z_POSITION_SCREENSHOT = -2.0f;
-    private static float WALL_X_POSITION_OBSERVATION = 7.0f;
-    private static float WALL_X_POSITION_INTERACTION = 5.5f;
+    private static float FLOOR_X_SCALE_OBSERVATION = 13f;
+    private static float FLOOR_X_SCALE_INTERACTION = 10f;
+    private static float FLOOR_Y_SCALE = 1f;
+    private static float FLOOR_Z_SCALE = 10f;
+    private static float WALL_SIDE_X_POSITION_OBSERVATION = 7.0f;
+    private static float WALL_SIDE_X_POSITION_INTERACTION = 5.5f;
     private static float WALL_Y_POSITION = 1.5f;
-    private static float WALL_Z_POSITION = 0;
+    private static float WALL_SIDE_Z_POSITION = 0;
+    private static float WALL_FRONT_X_POSITION = 0;
+    private static float WALL_FRONT_Y_POSITION_OBSERVATION = 2.25f;
+    private static float WALL_FRONT_Z_POSITION = 5.5f;
+    private static float WALL_FRONT_X_SCALE_OBSERVATION = 13.0f;
+    private static float WALL_FRONT_X_SCALE_INTERACTION = 10.0f;
+    private static float WALL_FRONT_Y_SCALE_OBSERVATION = 4.5f;
+    private static float WALL_FRONT_Y_SCALE_INTERACTION = 3.0f;
+    private static float WALL_FRONT_Z_SCALE = 1f;
 
     public string defaultSceneFile = "";
     public bool enableVerboseLog = false;
@@ -160,10 +173,18 @@ public class MachineCommonSenseMain : MonoBehaviour {
 
         if (this.currentScene.observation) {
             this.ceiling.SetActive(false);
-            this.wallLeft.transform.position = new Vector3(-1 * MachineCommonSenseMain.WALL_X_POSITION_OBSERVATION,
-                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_Z_POSITION);
-            this.wallRight.transform.position = new Vector3(MachineCommonSenseMain.WALL_X_POSITION_OBSERVATION,
-                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_Z_POSITION);
+
+            this.wallLeft.transform.position = new Vector3(-1 * MachineCommonSenseMain.WALL_SIDE_X_POSITION_OBSERVATION,
+                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_SIDE_Z_POSITION);
+            this.wallRight.transform.position = new Vector3(MachineCommonSenseMain.WALL_SIDE_X_POSITION_OBSERVATION,
+                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_SIDE_Z_POSITION);
+            this.wallFront.transform.position = new Vector3(MachineCommonSenseMain.WALL_FRONT_X_POSITION,
+                MachineCommonSenseMain.WALL_FRONT_Y_POSITION_OBSERVATION, MachineCommonSenseMain.WALL_FRONT_Z_POSITION);
+            this.wallFront.transform.localScale = new Vector3(MachineCommonSenseMain.WALL_FRONT_X_SCALE_OBSERVATION,
+                MachineCommonSenseMain.WALL_FRONT_Y_SCALE_OBSERVATION, MachineCommonSenseMain.WALL_FRONT_Z_SCALE);
+            this.floor.transform.localScale = new Vector3(MachineCommonSenseMain.FLOOR_X_SCALE_OBSERVATION,
+                MachineCommonSenseMain.FLOOR_Y_SCALE, MachineCommonSenseMain.FLOOR_Z_SCALE);
+
             this.currentScene.performerStart = new MachineCommonSenseConfigTransform();
             this.currentScene.performerStart.position = new MachineCommonSenseConfigVector();
             this.currentScene.performerStart.position.z = -4.5f;
@@ -171,11 +192,17 @@ public class MachineCommonSenseMain : MonoBehaviour {
         }
         else {
             this.ceiling.SetActive(true);
-            AssignMaterial(this.ceiling, ceilingMaterial);
-            this.wallLeft.transform.position = new Vector3(-1 * MachineCommonSenseMain.WALL_X_POSITION_INTERACTION,
-                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_Z_POSITION);
-            this.wallRight.transform.position = new Vector3(MachineCommonSenseMain.WALL_X_POSITION_INTERACTION,
-                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_Z_POSITION);
+
+            this.wallLeft.transform.position = new Vector3(-1 * MachineCommonSenseMain.WALL_SIDE_X_POSITION_INTERACTION,
+                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_SIDE_Z_POSITION);
+            this.wallRight.transform.position = new Vector3(MachineCommonSenseMain.WALL_SIDE_X_POSITION_INTERACTION,
+                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_SIDE_Z_POSITION);
+            this.wallFront.transform.position = new Vector3(MachineCommonSenseMain.WALL_FRONT_X_POSITION,
+                MachineCommonSenseMain.WALL_Y_POSITION, MachineCommonSenseMain.WALL_FRONT_Z_POSITION);
+            this.wallFront.transform.localScale = new Vector3(MachineCommonSenseMain.WALL_FRONT_X_SCALE_INTERACTION,
+                MachineCommonSenseMain.WALL_FRONT_Y_SCALE_INTERACTION, MachineCommonSenseMain.WALL_FRONT_Z_SCALE);
+            this.floor.transform.localScale = new Vector3(MachineCommonSenseMain.FLOOR_X_SCALE_INTERACTION,
+                MachineCommonSenseMain.FLOOR_Y_SCALE, MachineCommonSenseMain.FLOOR_Z_SCALE);
         }
 
 
@@ -190,11 +217,38 @@ public class MachineCommonSenseMain : MonoBehaviour {
                 MachineCommonSenseMain.LIGHT_Z_POSITION_SCREENSHOT);
         }
         else {
+            if (!this.currentScene.observation) {
+                SimObjPhysics ceilingSimObjPhysics = this.ceiling.GetComponent<SimObjPhysics>();
+                ceilingSimObjPhysics.VisibilityPoints = AssignVisibilityPoints(this.ceiling,
+                    this.GenerateCubeInternalVisibilityPoints(this.ceiling, null), false);
+                AssignMaterial(this.ceiling, ceilingMaterial);
+            }
+
+            SimObjPhysics floorSimObjPhysics = this.floor.GetComponent<SimObjPhysics>();
+            floorSimObjPhysics.VisibilityPoints = AssignVisibilityPoints(this.floor,
+                this.GenerateCubeInternalVisibilityPoints(this.floor, null), false);
             AssignMaterial(this.floor, floorMaterial);
+
+            SimObjPhysics wallLeftSimObjPhysics = this.wallLeft.GetComponent<SimObjPhysics>();
+            wallLeftSimObjPhysics.VisibilityPoints = AssignVisibilityPoints(this.wallLeft,
+                this.GenerateCubeInternalVisibilityPoints(this.wallLeft, null), false);
             AssignMaterial(this.wallLeft, wallsMaterial);
+
+            SimObjPhysics wallRightSimObjPhysics = this.wallRight.GetComponent<SimObjPhysics>();
+            wallRightSimObjPhysics.VisibilityPoints = AssignVisibilityPoints(this.wallRight,
+                this.GenerateCubeInternalVisibilityPoints(this.wallRight, null), false);
             AssignMaterial(this.wallRight, wallsMaterial);
+
+            SimObjPhysics wallFrontSimObjPhysics = this.wallFront.GetComponent<SimObjPhysics>();
+            wallFrontSimObjPhysics.VisibilityPoints = AssignVisibilityPoints(this.wallFront,
+                this.GenerateCubeInternalVisibilityPoints(this.wallFront, null), false);
             AssignMaterial(this.wallFront, wallsMaterial);
+
+            SimObjPhysics wallBackSimObjPhysics = this.wallBack.GetComponent<SimObjPhysics>();
+            wallBackSimObjPhysics.VisibilityPoints = AssignVisibilityPoints(this.wallBack,
+                this.GenerateCubeInternalVisibilityPoints(this.wallBack, null), false);
             AssignMaterial(this.wallBack, wallsMaterial);
+
             this.light.GetComponent<Light>().range = MachineCommonSenseMain.LIGHT_RANGE;
             this.light.transform.position = new Vector3(0, MachineCommonSenseMain.LIGHT_Y_POSITION,
                 MachineCommonSenseMain.LIGHT_Z_POSITION);
@@ -435,11 +489,6 @@ public class MachineCommonSenseMain : MonoBehaviour {
                 objectDefinition.scale.GetZ());
         }
 
-        if (objectConfig.structure) {
-            // Add the AI2-THOR Structure script with specific properties.
-            this.AssignStructureScript(gameObject);
-        }
-
         // See if each SimObjPhysics property is active on this specific object or on all objects of this type.
         // Currently you can't deactivate the properties on specific objects, since we don't need to do that right now.
         bool moveable = objectConfig.moveable || objectDefinition.moveable;
@@ -449,6 +498,14 @@ public class MachineCommonSenseMain : MonoBehaviour {
 
         bool shouldAddSimObjPhysicsScript = moveable || openable || pickupable || receptacle || objectConfig.physics ||
             objectDefinition.physics;
+
+        if (objectConfig.structure) {
+            // Add the AI2-THOR Structure script with specific properties.
+            this.AssignStructureScript(gameObject);
+            // Add the AI2-THOR SimObjPhysics script to generate visibility points for the structure so it will be
+            // returned in the output object metadata.
+            shouldAddSimObjPhysicsScript = true;
+        }
 
         Collider[] colliders = new Collider[] { };
         Transform[] visibilityPoints = new Transform[] { };
@@ -462,7 +519,13 @@ public class MachineCommonSenseMain : MonoBehaviour {
 
         // The object's visibility points define a subset of points along the outside of the object for AI2-THOR.
         if (objectDefinition.visibilityPoints.Count > 0) {
-            visibilityPoints = this.AssignVisibilityPoints(gameObject, objectDefinition.visibilityPoints,
+            // Use the List constructor to copy the visibility points list from the object definition.
+            List<MachineCommonSenseConfigVector> points = new List<MachineCommonSenseConfigVector>(
+                objectDefinition.visibilityPoints);
+            if (objectDefinition.id.Equals("cube")) {
+                points.AddRange(this.GenerateCubeInternalVisibilityPoints(gameObject, objectConfig));
+            }
+            visibilityPoints = this.AssignVisibilityPoints(gameObject, points,
                 objectDefinition.visibilityPointsScaleOne);
         }
 
@@ -859,6 +922,65 @@ public class MachineCommonSenseMain : MonoBehaviour {
         }
     }
 
+    private MachineCommonSenseConfigVector GenerateCubeInternalVisibilityPoint(float x, float y, float z) {
+        MachineCommonSenseConfigVector point = new MachineCommonSenseConfigVector();
+        point.x = x;
+        point.y = y;
+        point.z = z;
+        return point;
+    }
+
+    private List<MachineCommonSenseConfigVector> GenerateCubeInternalVisibilityPoints(
+        GameObject gameObject,
+        MachineCommonSenseConfigGameObject objectConfig
+    ) {
+        MachineCommonSenseConfigShow showConfig = (objectConfig != null && objectConfig.shows.Count > 0) ?
+            objectConfig.shows[0] : null;
+
+        float xSize = showConfig != null ? showConfig.scale.GetX() : gameObject.transform.localScale.x;
+        float ySize = showConfig != null ? showConfig.scale.GetY() : gameObject.transform.localScale.y;
+        float zSize = showConfig != null ? showConfig.scale.GetZ() : gameObject.transform.localScale.z;
+
+        float xGrid = Mathf.Floor(xSize / MachineCommonSenseMain.CUBE_INTERNAL_GRID);
+        float yGrid = Mathf.Floor(ySize / MachineCommonSenseMain.CUBE_INTERNAL_GRID);
+        float zGrid = Mathf.Floor(zSize / MachineCommonSenseMain.CUBE_INTERNAL_GRID);
+
+        float xSpan = xSize / xGrid;
+        float ySpan = ySize / yGrid;
+        float zSpan = zSize / zGrid;
+
+        List<MachineCommonSenseConfigVector> points = new List<MachineCommonSenseConfigVector>();
+
+        for (float x = 1; x < xGrid; ++x) {
+            for (float y = 1; y < yGrid; ++y) {
+                float xPosition = (x * xSpan) - (xSize / 2f);
+                float yPosition = (y * ySpan) - (ySize / 2f);
+                points.Add(this.GenerateCubeInternalVisibilityPoint(xPosition, yPosition, 0.5f));
+                points.Add(this.GenerateCubeInternalVisibilityPoint(xPosition, yPosition, -0.5f));
+            }
+        }
+
+        for (float y = 1; y < yGrid; ++y) {
+            for (float z = 1; z < zGrid; ++z) {
+                float yPosition = (y * ySpan) - (ySize / 2f);
+                float zPosition = (z * zSpan) - (zSize / 2f);
+                points.Add(this.GenerateCubeInternalVisibilityPoint(0.5f, yPosition, zPosition));
+                points.Add(this.GenerateCubeInternalVisibilityPoint(-0.5f, yPosition, zPosition));
+            }
+        }
+
+        for (float x = 1; x < xGrid; ++x) {
+            for (float z = 1; z < zGrid; ++z) {
+                float xPosition = (x * xSpan) - (xSize / 2f);
+                float zPosition = (z * zSpan) - (zSize / 2f);
+                points.Add(this.GenerateCubeInternalVisibilityPoint(xPosition, 0.5f, zPosition));
+                points.Add(this.GenerateCubeInternalVisibilityPoint(xPosition, -0.5f, zPosition));
+            }
+        }
+
+        return points;
+    }
+
     private void InitializeGameObject(MachineCommonSenseConfigGameObject objectConfig) {
         try {
             GameObject gameObject = CreateGameObject(objectConfig);
@@ -1124,7 +1246,6 @@ public class MachineCommonSenseMain : MonoBehaviour {
                 });
         }
     }
-
 }
 
 // Definitions of serializable objects from JSON config files.


### PR DESCRIPTION
- Structural objects like walls are now assigned the SimObjPhysics script, so we can use the AI2-THOR code to determine if structural objects are visible (we mark them as kinematic so physics and gravity doesn't affect them).
- Dynamically assign visibility points to walls, so bigger walls automatically have more visibility points.
- Dynamically adjust the size of room walls so the output metadata makes more sense.
- Adjusted properties of room walls in MCS scene, adding the SimObjPhysics script and other required components.
- Return structural object metadata to the Python API.