### PR TITLE
MCS-163 Use PutObject Action with Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,20 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
   - Added `lastActionStatus` to `Initialize` to help indicate success or failure
 - `Scripts/CanOpen_Object`:
   - Rewrote part of the `Interact` function so it doesn't use iTween if `animationTime` is `0`.  Also the `Interact` function now uses the `openPercentage` on both "open" and "close".
+- `Scripts/Contains`:
+  - In `GetValidSpawnPoints`, rewrote the method so that it generates the spawn points based on the global UP (which may actually be down, left, right, forward, or back) rather than the receptacle object's local UP, so the grid may be X/Y, X/Z, or Y/Z.
+  - In `CheckIfPointIsInsideReceptacleTriggerBox`, if the receptacle trigger box's parent object has the `Stacking` secondary property, just ensure that the point is above the receptacle trigger box's bottom Y point.
+  - In `CheckIfPointIsInsideReceptacleTriggerBox`, fixed how the receptacle trigger box center and size are calculated so that its transform, its parent's transform(s), and its collider are all used.
+  - Added the `FindReceptacleTriggerBoxSize` method to implemented the behavior in the previous bullet.
+  - Removed the `CheckIfPointIsAboveReceptacleTriggerBox` method because it is no longer used (due to corresponding changes in `InstantiatePrefabTest`) and is also redundant with `CheckIfPointIsInsideReceptacleTriggerBox`.
 - `Scripts/DebugDiscreteAgentController`:
   - Calls `ProcessControlCommand` on the controller object with an "Initialize" action in its `Start` function (so the Unity Editor Workflow mimics the Python API Workflow)
   - Added a way to "Pass" (with the "Escape" button) or "Initialize" (with the "Backspace" button) on a step while playing the game in the Unity Editor
   - Added support for executing other actions and properties while playing the game in the Unity Editor
 - `Scripts/InstantiatePrefabTest`:
-  - Fixed a bug in the `CheckSpawnArea` function in which the object's bounding box was not adjusted by the object's scale.
+  - In `PlaceObject`, fixed object rotation so that it always rotates around the global DOWN rather than using the receptacle object's local rotation.
+  - In `PlaceObject`, removed the `HowManyCornersToCheck` behavior because it was buggy (there's no way to guarantee that the 4 correct corners are always the 4 bottom corners).
+  - In `CheckSpawnArea`, fixed how the object bounding box center and size are calculated so that its transform, its parent's transform, and its collider are all used.
 - `Scripts/PhysicsRemoteFPSAgentController`:
   - Changed variables or functions from `private` to `protected`: `physicsSceneManager`, `ObjectMetadataFromSimObjPhysics`
   - Added `virtual` to functions: `CloseObject`, `DropHandObject`, `OpenObject`, `PickupObject`, `PullObject`, `PushObject`, `PutObject`, `ResetAgentHandPosition`, `ThrowObject`, `ToggleObject`
@@ -165,6 +173,7 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
   - Make sure objectId specified is actually the object being held for `DropHandObject` and `PutObject`
   - Undid objectId being reset to receptableObjectId and not allowing objects to be placed in closed receptacles regardless of type of receptacle for `PutObject`
   - In `PickupContainedObjects` and `DropContainedObjects`, added a null check for the Colliders object and added a loop over the colliders array in the SimObjPhysics script.
+  - In `PickupContainedObjects`, don't pickup contained objects if the receptacle has the `Stacking` secondary property.
   - Added code to allow movement that will auto calculate the space to close the distance to an object within 0.1f
   - In 'CheckIfAgentCanTurn' and 'CheckIfAgentCanLook' add a check to see if object in hand is active
 - `Scripts/PhysicsSceneManager`:
@@ -174,6 +183,7 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
   - Added `ApplyRelativeForce` to apply force in a direction relative to the agent's current position.
 - `Scripts/SimObjType`:
   - Added `IgnoreType` to the `SimObjType` enum, `ReturnAllPoints`, and `AlwaysPlaceUpright`
+  - Added `Stacking` to the `SimObjSecondaryProperty` enum.
 - `Scripts/MachineCommonSenseController`:
   - Added custom `RotateLook` to use relative inputs instead of absolute values.
   - Added checks to see whether objects exist and set lastActionStatus appropriately for `PutObject`

--- a/unity/Assets/Resources/MCS/mcs_object_registry.json
+++ b/unity/Assets/Resources/MCS/mcs_object_registry.json
@@ -6,6 +6,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -18,6 +20,73 @@
                 "z": 0.01
             }
         },
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": 0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": -0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": -0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -82,6 +151,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -94,6 +165,73 @@
                 "z": 0.01
             }
         },
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": 0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": -0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": -0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -158,6 +296,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -170,6 +310,73 @@
                 "z": 0.01
             }
         },
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": 0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": -0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": -0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -234,6 +441,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -246,6 +455,73 @@
                 "z": 0.01
             }
         },
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": 0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": -0.006,
+                "y": 0.005,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.005,
+                "z": -0.006
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -310,6 +586,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -322,6 +600,43 @@
                 "z": 0.01
             }
         },
+        "keepColliders": true,
+        "colliders": [{
+            "type": "box",
+            "position": {
+                "x": 0,
+                "y": 0.05,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.06,
+                "y": 0.1,
+                "z": 0.06
+            }
+        }],
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -386,6 +701,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -398,6 +715,43 @@
                 "z": 0.01
             }
         },
+        "keepColliders": true,
+        "colliders": [{
+            "type": "box",
+            "position": {
+                "x": 0,
+                "y": 0.05,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.06,
+                "y": 0.1,
+                "z": 0.06
+            }
+        }],
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -462,6 +816,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -474,6 +830,43 @@
                 "z": 0.01
             }
         },
+        "keepColliders": true,
+        "colliders": [{
+            "type": "box",
+            "position": {
+                "x": 0,
+                "y": 0.05,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.06,
+                "y": 0.1,
+                "z": 0.06
+            }
+        }],
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -538,6 +931,8 @@
         "materialRestrictions": ["block_blank"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "boundingBox": {
             "position": {
                 "x": 0,
@@ -550,6 +945,43 @@
                 "z": 0.01
             }
         },
+        "keepColliders": true,
+        "colliders": [{
+            "type": "box",
+            "position": {
+                "x": 0,
+                "y": 0.05,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.06,
+                "y": 0.1,
+                "z": 0.06
+            }
+        }],
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 0,
+                "y": 0.011,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.001,
+                "z": 0
+            },
+            "scale": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.05,
             "y": 0,
@@ -614,6 +1046,8 @@
         "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "scale": {
             "x": 0.1,
             "y": 0.1,
@@ -642,6 +1076,73 @@
                 "x": 0.104,
                 "y": 0.104,
                 "z": 0.104
+            }
+        }],
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 1.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": 1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }, {
+            "position": {
+                "x": -1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": -1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
             }
         }],
         "visibilityPoints": [{
@@ -708,6 +1209,8 @@
         "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "scale": {
             "x": 0.1,
             "y": 0.1,
@@ -736,6 +1239,73 @@
                 "x": 0.104,
                 "y": 0.104,
                 "z": 0.104
+            }
+        }],
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 1.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": 1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }, {
+            "position": {
+                "x": -1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": -1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
             }
         }],
         "visibilityPoints": [{
@@ -802,6 +1372,8 @@
         "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "scale": {
             "x": 0.1,
             "y": 0.1,
@@ -830,6 +1402,73 @@
                 "x": 0.104,
                 "y": 0.104,
                 "z": 0.104
+            }
+        }],
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 1.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": 1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }, {
+            "position": {
+                "x": -1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": -1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
             }
         }],
         "visibilityPoints": [{
@@ -896,6 +1535,8 @@
         "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "scale": {
             "x": 0.1,
             "y": 0.1,
@@ -913,6 +1554,73 @@
                 "z": 1.04
             }
         },
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 1.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": 1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }, {
+            "position": {
+                "x": -1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": -1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.057,
             "y": -0.007,
@@ -977,6 +1685,8 @@
         "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "scale": {
             "x": 0.1,
             "y": 0.1,
@@ -994,6 +1704,73 @@
                 "z": 1.04
             }
         },
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 1.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": 1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }, {
+            "position": {
+                "x": -1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": -1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.057,
             "y": -0.007,
@@ -1058,6 +1835,8 @@
         "materialRestrictions": ["block_design"],
         "salientMaterials": ["wood"],
         "pickupable": true,
+        "receptacle": true,
+        "stacking": true,
         "scale": {
             "x": 0.1,
             "y": 0.1,
@@ -1075,6 +1854,73 @@
                 "z": 1.04
             }
         },
+        "receptacleTriggerBoxes": [{
+            "position": {
+                "x": 1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 1.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": 1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }, {
+            "position": {
+                "x": -1,
+                "y": 0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.04,
+                "y": 1.54,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": -0.5,
+                "z": 0
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.04,
+                "z": 1.54
+            }
+        }, {
+            "position": {
+                "x": 0,
+                "y": 0.5,
+                "z": -1
+            },
+            "scale": {
+                "x": 1.54,
+                "y": 1.54,
+                "z": 1.04
+            }
+        }],
         "visibilityPoints": [{
             "x": 0.057,
             "y": -0.007,

--- a/unity/Assets/Scripts/Contains.cs
+++ b/unity/Assets/Scripts/Contains.cs
@@ -218,7 +218,7 @@ public class Contains : MonoBehaviour
             objectUpVector = objectSideTop.x > objectSideBottom.x ? Vector3.left : Vector3.right;
             verticalDistance = xDiff;
         }
-        if (zDiff > yDiff && zDiff > xDiff) {
+        else if (zDiff > yDiff && zDiff > xDiff) {
             objectUpVector = objectSideTop.z > objectSideBottom.z ? Vector3.forward : Vector3.back;
             verticalDistance = zDiff;
         }
@@ -259,7 +259,7 @@ public class Contains : MonoBehaviour
                 float x = objectSideLeft.x + ((objectSideRight.x - objectSideLeft.x) * (lineincrement * i));
                 float z = objectUpVector.Equals(Vector3.forward) ? objectSideForward.z : objectSideBack.z;
                 for(int j = 0; j < linepoints; j++) {
-                    float y = objectSideBottom.y + ((objectSideTop.y - objectSideBottom.y) * (lineincrement * i));
+                    float y = objectSideBottom.y + ((objectSideTop.y - objectSideBottom.y) * (lineincrement * j));
                     gridpoints.Add(new Vector3(x, y, z));
                 }
             }

--- a/unity/Assets/Scripts/Contains.cs
+++ b/unity/Assets/Scripts/Contains.cs
@@ -223,6 +223,7 @@ public class Contains : MonoBehaviour
             verticalDistance = zDiff;
         }
 
+        // TODO MCS-226 Adjust number of spawn points by receptacle trigger box size
 		//so lets make a grid, we can parametize the gridsize value later, for now we'll adjust it here
 		int gridsize = 4; //number of grid boxes we want, reduce this to SPEED THINGS UP but also GET WAY MORE INACCURATE
 		int linepoints = gridsize + 1; //number of points on the line we need to make the number of grid boxes

--- a/unity/Assets/Scripts/InstantiatePrefabTest.cs
+++ b/unity/Assets/Scripts/InstantiatePrefabTest.cs
@@ -288,6 +288,7 @@ public class InstantiatePrefabTest : MonoBehaviour
         {
             oabb.enabled = true;
 
+            // Set the new rotation rather than using Transform.Rotate because we want to ignore the receptacle object's local rotation.
             sop.transform.rotation = Quaternion.Euler(sop.transform.localRotation.x, i * degreeIncrement, sop.transform.localRotation.z);
 
             Vector3 Offset = oabb.ClosestPoint(oabb.transform.TransformPoint(oabb.center) + Vector3.down * 10);

--- a/unity/Assets/Scripts/MachineCommonSenseController.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseController.cs
@@ -131,10 +131,16 @@ public class MachineCommonSenseController : PhysicsRemoteFPSAgentController {
         MetadataWrapper metadata = base.generateMetadataWrapper();
         metadata.lastActionStatus = this.lastActionStatus;
         metadata.reachDistance = this.maxVisibleDistance;
-        metadata.structuralObjects = metadata.objects.ToList().Where(objectMetadata =>
-            GameObject.Find(objectMetadata.name).GetComponent<StructureObject>() != null).ToArray();
-        metadata.objects = metadata.objects.ToList().Where(objectMetadata =>
-            GameObject.Find(objectMetadata.name).GetComponent<StructureObject>() == null).ToArray();
+        metadata.structuralObjects = metadata.objects.ToList().Where(objectMetadata => {
+            GameObject gameObject = GameObject.Find(objectMetadata.name);
+            // The object may be null if it is being held.
+            return gameObject != null && gameObject.GetComponent<StructureObject>() != null;
+        }).ToArray();
+        metadata.objects = metadata.objects.ToList().Where(objectMetadata => {
+            GameObject gameObject = GameObject.Find(objectMetadata.name);
+            // The object may be null if it is being held.
+            return gameObject == null || gameObject.GetComponent<StructureObject>() == null;
+        }).ToArray();
         return this.agentManager.UpdateMetadataColors(this, metadata);
     }
 

--- a/unity/Assets/Scripts/MachineCommonSenseMain.cs
+++ b/unity/Assets/Scripts/MachineCommonSenseMain.cs
@@ -719,6 +719,7 @@ public class MachineCommonSenseMain : MonoBehaviour {
 
         // The object's receptacle trigger boxes define the area in which objects may be placed for AI2-THOR.
         if (receptacle && objectDefinition.receptacleTriggerBoxes.Count > 0) {
+            ai2thorPhysicsScript.ContainedObjectReferences = new List<SimObjPhysics>();
             ai2thorPhysicsScript.ReceptacleTriggerBoxes = this.AssignReceptacleTriggerBoxes(gameObject,
                 objectDefinition);
         }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4209,7 +4209,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //make sure not to pick up any sliced objects because those should remain uninteractable i they have been sliced
         public void PickupContainedObjects(SimObjPhysics target) 
         {
-            if (target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle)) 
+            if (target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle) && !target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Stacking))
             {
                 foreach (SimObjPhysics sop in target.ReceptacleObjects) 
                 {

--- a/unity/Assets/Scripts/SimObjType.cs
+++ b/unity/Assets/Scripts/SimObjType.cs
@@ -96,6 +96,8 @@ public enum SimObjSecondaryProperty : int //EACH SimObjPhysics can have any numb
     CanLightOnFire = 50,
     CanSeeThrough = 51,
 	ObjectSpecificReceptacle = 52,
+
+    Stacking = 999999999
 }
 
 [Serializable]


### PR DESCRIPTION
Goal:  Label blocks as "receptacles" so we can use the PutObject action to put other objects on top of them.

- Rewrote the method that generates receptacle spawn points so it always translates global UP into a local direction (which may be down/left/right/forward/back) instead of just using local UP, in case a block is ever lying on its side.  Rewrote other pieces of code to always use global UP.
- Rewrote multiple pieces of code to calculate the size of box colliders to properly account for all types of scaling.  This includes the base object, its receptacle trigger box object, its receptacle trigger box collider, and sometimes an intermediary object.
- Added a new AI2-THOR secondary property, called "stacking", so that larger objects can be stacked on top of small blocks.  Additionally, picking up blocks does not automatically pick up their "contained" objects (which are any small adjacent objects within the block's receptacle trigger boxes).
- Added receptacle trigger boxes to the block definitions in the object registry.  Also added an internal box collider to the cylinder blocks in addition to their mesh collider (that correctly detects collisions with the cylinder's exterior) because its mesh doesn't have any vertices in its center and wasn't correctly detecting collisions if a smaller object was positioned in its center.
- Tested with the blocks, chairs, drawers, shelves, and tables in the playroom.

We'll need to change the merge base branch before finalizing the merge.