### PR TITLE
Mcs 83

### DIFF
--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.69955504, g: 0.7222365, b: 0.7302953, a: 1}
+  m_IndirectSpecularColor: {r: 0.6995551, g: 0.7222365, b: 0.7302953, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3099,7 +3099,7 @@ PrefabInstance:
     - target: {fileID: 3388362411129917294, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: moveOrPickupObjectId
-      value: "apple_a\x13"
+      value: apple_a
       objectReference: {fileID: 0}
     - target: {fileID: 3388362411129917294, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -3099,7 +3099,7 @@ PrefabInstance:
     - target: {fileID: 3388362411129917294, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: moveOrPickupObjectId
-      value: ball_d
+      value: "apple_a\x13"
       objectReference: {fileID: 0}
     - target: {fileID: 3388362411129917294, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -3099,7 +3099,7 @@ PrefabInstance:
     - target: {fileID: 3388362411129917294, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: moveOrPickupObjectId
-      value: apple_a
+      value: ball_d
       objectReference: {fileID: 0}
     - target: {fileID: 3388362411129917294, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2240,37 +2240,34 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         public void ApplyForceObject(ServerAction action) {
-            SimObjPhysics target = null;
 
-            GameObject player = this.GetComponent<GameObject>();
+            GameObject player = this.gameObject;
 
             if (action.forceAction) {
                 action.forceVisible = true;
             }
 
-            SimObjPhysics[] simObjPhysicsArray = VisibleSimObjs(action);
-
-            foreach (SimObjPhysics sop in simObjPhysicsArray) {
-                if (action.objectId == sop.UniqueID) {
-                    target = sop;
-                }
-            }
+            SimObjPhysics target = physicsSceneManager.UniqueIdToSimObjPhysics[action.objectId];
             
-            /*
-            if (objectIsCurrentlyVisible(target, maxVisibleDistance)) {
-                errorMessage = "Target " + action.objectId + " is obstructed.";
-                Debug.Log(errorMessage);
-                Debug.Log(player.transform.position.x);
-                actionFinished(false);
-                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
-                return;
-            }*/
+            if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) { 
+                Vector3 tmp = target.transform.position;
+                tmp.y = transform.position.y;
+                if (Vector3.Distance(tmp, transform.position) < maxVisibleDistance) {
+                    errorMessage = "Target " + action.objectId + " is obstructed.";
+                    Debug.Log(errorMessage);
+                    Debug.Log(string.Format("Agent - X position: {0} - Z position {1}.", player.transform.position.x, player.transform.position.z));
+                    actionFinished(false);
+                    this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
+                    return;
+                }
+                
+            }
 
             // TODO: MCS-83: Need to split into OUT_OF_REACH and OBSTRUCTED
-            if (target == null) {
+            if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) {
                 errorMessage = "Target " + action.objectId + " is not visible";
                 Debug.Log(errorMessage);
-                Debug.Log(player.transform.position.x);
+                Debug.Log(string.Format("Agent - X position: {0} - Z position {1}.", player.transform.position.x, player.transform.position.z));
                 actionFinished(false);
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
                 return;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2250,9 +2250,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             SimObjPhysics target = physicsSceneManager.UniqueIdToSimObjPhysics[action.objectId];
             
             if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) { 
-                Vector3 tmp = target.transform.position;
-                tmp.y = transform.position.y;
-                if (Vector3.Distance(tmp, transform.position) < maxVisibleDistance) {
+                Vector3 targetMoveYHeightToAgentHeight = target.transform.position;
+                targetMoveYHeightToAgentHeight.y = transform.position.y;
+                if (Vector3.Distance(targetMoveYHeightToAgentHeight, transform.position) < maxVisibleDistance) {
                     errorMessage = "Target " + action.objectId + " is obstructed.";
                     Debug.Log(errorMessage);
                     Debug.Log(string.Format("Agent - X position: {0} - Z position {1}.", player.transform.position.x, player.transform.position.z));
@@ -4148,9 +4148,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) { 
-                Vector3 tmp = target.transform.position;
-                tmp.y = transform.position.y;
-                if (Vector3.Distance(tmp, transform.position) < maxVisibleDistance) {
+                Vector3 targetMoveYHeightToAgentHeight = target.transform.position;
+                targetMoveYHeightToAgentHeight.y = transform.position.y;
+                if (Vector3.Distance(targetMoveYHeightToAgentHeight, transform.position) < maxVisibleDistance) {
                     errorMessage = "Target " + action.objectId + " is obstructed.";
                     Debug.Log(errorMessage);
                     actionFinished(false);

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2262,8 +2262,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
                 
             }
-
-            // TODO: MCS-83: Need to split into OUT_OF_REACH and OBSTRUCTED
+            
             if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) {
                 errorMessage = "Target " + action.objectId + " is not visible";
                 Debug.Log(errorMessage);
@@ -4148,7 +4147,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            // TODO: MCS-83: Need to split into OUT_OF_REACH and OBSTRUCTED
             if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) { 
                 Vector3 tmp = target.transform.position;
                 tmp.y = transform.position.y;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2255,10 +2255,20 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     target = sop;
                 }
             }
+            
+            /*
+            if (objectIsCurrentlyVisible(target, maxVisibleDistance)) {
+                errorMessage = "Target " + action.objectId + " is obstructed.";
+                Debug.Log(errorMessage);
+                Debug.Log(player.transform.position.x);
+                actionFinished(false);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
+                return;
+            }*/
 
             // TODO: MCS-83: Need to split into OUT_OF_REACH and OBSTRUCTED
             if (target == null) {
-                errorMessage = "Target " + action.objectId + " is not visible.";
+                errorMessage = "Target " + action.objectId + " is not visible";
                 Debug.Log(errorMessage);
                 Debug.Log(player.transform.position.x);
                 actionFinished(false);
@@ -4142,6 +4152,19 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             }
 
             // TODO: MCS-83: Need to split into OUT_OF_REACH and OBSTRUCTED
+            if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) { 
+                Vector3 tmp = target.transform.position;
+                tmp.y = transform.position.y;
+                if (Vector3.Distance(tmp, transform.position) < maxVisibleDistance) {
+                    errorMessage = "Target " + action.objectId + " is obstructed.";
+                    Debug.Log(errorMessage);
+                    actionFinished(false);
+                    this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
+                    return;
+                }
+                
+            }
+
             if (!action.forceAction && !objectIsCurrentlyVisible(target, maxVisibleDistance)) {
                 errorMessage = action.objectId + " is not visible.";
                 actionFinished(false);

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2242,6 +2242,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         public void ApplyForceObject(ServerAction action) {
             SimObjPhysics target = null;
 
+            GameObject player = this.GetComponent<GameObject>();
+
             if (action.forceAction) {
                 action.forceVisible = true;
             }
@@ -2258,6 +2260,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (target == null) {
                 errorMessage = "Target " + action.objectId + " is not visible.";
                 Debug.Log(errorMessage);
+                Debug.Log(player.transform.position.x);
                 actionFinished(false);
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
                 return;


### PR DESCRIPTION
https://nextcentury.atlassian.net/browse/MCS-83
The reason I moved the target up to the agents y height for the check is because that was how it is done to check if an object is currently visible in:

objectIsCurrentlyVisible(SimObjPhysics sop, float maxDistance). 

I figured I would follow that same logic since their code came first. Thought it was a bit odd as it effectively cancels out any y axis distance between the agent and target. Since I'm using the method though, best to use it's logic.

Also was hesitant about doing an else{} where you think it would go because every error was setup nicely in its own distinct if block before.
Could go back and change it though if you think it is the better way to do it