### PR TITLE
MCS-275 Fix Cup Not Visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
   - Added logic to `InteractAndWait` to reset an object to its prior position if open/close action fails, and to increase the radius used to check if an agent is in the way of the object to be opened/closed.
   - For `OpenObject` and `CloseObject`, only use coroutine if physics are enabled.
   - In `isAgentCapsuleCollidingWith`, added expandBy parameter.
+  - Change the layer of the `ItemInHand` to `SimObjInvisible` when picked up and to `SimObjVisible` when put/dropped/thrown.
 - `Scripts/PhysicsSceneManager`:
   - Added `virtual` to functions: `Generate_UniqueID`
 - `Scripts/SimObjPhysics`:

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4005,6 +4005,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     ItemInHand.transform.localRotation = Quaternion.identity;
                     ItemInHand.GetComponent<Rigidbody>().isKinematic = true;
                     ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;//remove in agent hand flag
+                    ItemInHand.layer = 8;
                     ItemInHand = null;
                     DefaultAgentHand();
                     actionFinished(true);
@@ -4093,6 +4094,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // MCS CHANGE END
 
             if (script.PlaceObjectReceptacle(spawnPoints, ItemInHand.GetComponent<SimObjPhysics>(), action.placeStationary, -1, 90, placeUpright, null)) {
+                ItemInHand.layer = 8;
                 ItemInHand = null;
                 DefaultAgentHand();
 
@@ -4203,6 +4205,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             target.transform.rotation = transform.rotation;
             target.transform.SetParent(AgentHand.transform);
             ItemInHand = target.gameObject;
+            ItemInHand.layer = 9;
 
             /* TODO MCS
             if (!action.forceAction && isHandObjectColliding(true)) {
@@ -4447,6 +4450,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     actionFinished(true);
 
                     ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;
+                    ItemInHand.layer = 8;
                     ItemInHand = null;
                     this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
                     return true;
@@ -8543,6 +8547,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         }
 
                         targetsop.isInAgentHand = false;
+                        ItemInHand.layer = 8;
                         ItemInHand = null;
                         DefaultAgentHand();
                         //ok now we are ready to break go go go

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4005,7 +4005,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     ItemInHand.transform.localRotation = Quaternion.identity;
                     ItemInHand.GetComponent<Rigidbody>().isKinematic = true;
                     ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;//remove in agent hand flag
-                    ItemInHand.layer = 8;
+                    ItemInHand.layer = 8; // SimObjVisible
                     ItemInHand = null;
                     DefaultAgentHand();
                     actionFinished(true);
@@ -4094,7 +4094,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // MCS CHANGE END
 
             if (script.PlaceObjectReceptacle(spawnPoints, ItemInHand.GetComponent<SimObjPhysics>(), action.placeStationary, -1, 90, placeUpright, null)) {
-                ItemInHand.layer = 8;
+                ItemInHand.layer = 8; // SimObjVisible
                 ItemInHand = null;
                 DefaultAgentHand();
 
@@ -4205,7 +4205,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             target.transform.rotation = transform.rotation;
             target.transform.SetParent(AgentHand.transform);
             ItemInHand = target.gameObject;
-            ItemInHand.layer = 9;
+            ItemInHand.layer = 9; // SimObjInvisible
 
             /* TODO MCS
             if (!action.forceAction && isHandObjectColliding(true)) {
@@ -4450,7 +4450,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     actionFinished(true);
 
                     ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;
-                    ItemInHand.layer = 8;
+                    ItemInHand.layer = 8; // SimObjVisible
                     ItemInHand = null;
                     this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
                     return true;
@@ -8547,7 +8547,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         }
 
                         targetsop.isInAgentHand = false;
-                        ItemInHand.layer = 8;
+                        ItemInHand.layer = 8; // SimObjVisible
                         ItemInHand = null;
                         DefaultAgentHand();
                         //ok now we are ready to break go go go


### PR DESCRIPTION
Problem:  Held objects, while not active (invisible), still obstruct the raycasting that determines whether an object is visible in the metadata (i.e. the invisible held block hides the cup on the ground).

Solution:  Switch held objects to the AI2-THOR "invisible" layer while held so they are ignored when raycasting to determine object visibility.
