### PR TITLE
MCS-284 Fixed Metadata Sync Bug

### DIFF
--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -466,13 +466,14 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     }
 
     private IEnumerator SimulatePhysicsSaveImagesIncreaseStep(int thisLoop) {
-        yield return new WaitForEndOfFrame(); // Required for coroutine functions
-
         // Run the physics simulation for a little bit, then pause and save the images for the current scene.
         this.SimulatePhysicsOnce();
 
         GameObject.Find("MCS").GetComponent<MCSMain>().UpdateOnPhysicsSubstep(
             MCSController.PHYSICS_SIMULATION_LOOPS);
+
+        // Wait for the end of frame after we run the physics simulation but before we save the images.
+        yield return new WaitForEndOfFrame(); // Required for coroutine functions
 
         ((MCSPerformerManager)this.agentManager).SaveImages(this.imageSynthesis);
 


### PR DESCRIPTION
Fixed an issue in which the output images weren't syncing correctly with the output object metadata.

Before, the first image of the `image_list` for a given step was actually supposed to be the last image of the `image_list` for the previous step.