### PR TITLE
MCS-278 - Fix for DropObject FAILED status

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ tar -czvf MCS-AI2-THOR-Unity-App-<version>_Data.tar.gz MCS-AI2-THOR-Unity-App-<v
 - In the `PhysicsSceneManager` object, I replaced the `AgentManager` script with our `MachineCommonSensePerformerManager` script.
 - Added structural objects (walls, floor, ceiling).
 - Added the invisible `MCS` object containing our `MachineCommonSenseMain` script that runs in the background.
+- The `FPSController` prefab now has the AgentHand at the top level (instead of under `FirstPersonCharacter`), so that it is no longer affected by head tilt/camera.
 
 ## Code Workflow
 
@@ -197,6 +198,8 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
   - Changed 'CheckIfAgentCanMove' to take a reference to a directionMagnitude instead of a copy parameter, so if distance to object is greater than zero, we can move a partial distance in 'moveInDirection' by adjusting the Vector3
   - If `PushObject` or `PullObject` is called on a held object, `ThrowObject` will be called instead of throwing an error.
   - Update ReceptacleObjects if needed in `PickupObject`.
+- `Scripts/UtilityFunctions`:
+  - Ignore checking collisions on ReceptacleTriggerBoxes in `isObjectColliding`
 - `ImageSynthesis/ImageSynthesis`:
   - Added a null check in `OnSceneChange`
   - Changed to always use the `Hidden/Depth` Shader

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -9,7 +9,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     public static float POSITION_Y = 0.4625f;
 
     public static float DISTANCE_HELD_OBJECT_Y = 0.15f;
-    public static float DISTANCE_HELD_OBJECT_Z = 0.15f;
+    public static float DISTANCE_HELD_OBJECT_Z = 0.30f;
 
     // TODO MCS-95 Make the room size configurable in the scene configuration file.
     // The room dimensions are always 10x10 so the distance from corner to corner is around 14.15

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -9,7 +9,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     public static float POSITION_Y = 0.4625f;
 
     public static float DISTANCE_HELD_OBJECT_Y = 0.15f;
-    public static float DISTANCE_HELD_OBJECT_Z = 0.15f;
+    public static float DISTANCE_HELD_OBJECT_Z = 0.20f;
 
     // TODO MCS-95 Make the room size configurable in the scene configuration file.
     // The room dimensions are always 10x10 so the distance from corner to corner is around 14.15

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -9,7 +9,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     public static float POSITION_Y = 0.4625f;
 
     public static float DISTANCE_HELD_OBJECT_Y = 0.15f;
-    public static float DISTANCE_HELD_OBJECT_Z = 0.30f;
+    public static float DISTANCE_HELD_OBJECT_Z = 0.15f;
 
     // TODO MCS-95 Make the room size configurable in the scene configuration file.
     // The room dimensions are always 10x10 so the distance from corner to corner is around 14.15

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4396,9 +4396,18 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     return false;
                 }
 
+                // Ignoring the floor for upcoming collision check (some objects are large enough
+                // that they will collide with floor even while held)
+                List<GameObject> ignoreCollisions = new List<GameObject>();
+                GameObject floor = GameObject.Find("Floor");
+
+                if(floor != null) {
+                    ignoreCollisions.Add(floor);
+                }
+
                 //we do need this to check if the item is currently colliding with the agent, otherwise
                 //dropping an object while it is inside the agent will cause it to shoot out weirdly
-                if (!action.forceAction && isHandObjectColliding(false)) {
+                if (!action.forceAction && isHandObjectColliding(false, ignoreCollisions)) {
                     errorMessage = ItemInHand.transform.name + " can't be dropped. It must be clear of all other collision first, including the Agent";
                     Debug.Log(errorMessage);
                     actionFinished(false);
@@ -6585,13 +6594,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         //to ignore the agent in this collision check, set ignoreAgent to true
-        protected bool isHandObjectColliding(bool ignoreAgent = false, float expandBy = 0.0f) {
+        protected bool isHandObjectColliding(bool ignoreAgent = false, List<GameObject> ignoreGameObjects = null, float expandBy = 0.0f) {
             if (ItemInHand == null) {
                 return false;
             }
-            List<GameObject> ignoreGameObjects = new List<GameObject>();
+
+            if(ignoreGameObjects == null) {
+                ignoreGameObjects = new List<GameObject>();
+            }
+
             // Ignore the agent when determining if the hand object is colliding
-            if (ignoreAgent) {
+            if (ignoreAgent && !ignoreGameObjects.Contains(this.gameObject)) {
                 ignoreGameObjects.Add(this.gameObject);
             }
             return UtilityFunctions.isObjectColliding(ItemInHand, ignoreGameObjects, expandBy);

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4396,18 +4396,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     return false;
                 }
 
-                // Ignoring the floor for upcoming collision check (some objects are large enough
-                // that they will collide with floor even while held)
-                List<GameObject> ignoreCollisions = new List<GameObject>();
-                GameObject floor = GameObject.Find("Floor");
-
-                if(floor != null) {
-                    ignoreCollisions.Add(floor);
-                }
-
                 //we do need this to check if the item is currently colliding with the agent, otherwise
                 //dropping an object while it is inside the agent will cause it to shoot out weirdly
-                if (!action.forceAction && isHandObjectColliding(false, ignoreCollisions)) {
+                if (!action.forceAction && isHandObjectColliding(false)) {
                     errorMessage = ItemInHand.transform.name + " can't be dropped. It must be clear of all other collision first, including the Agent";
                     Debug.Log(errorMessage);
                     actionFinished(false);
@@ -6594,17 +6585,13 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         }
 
         //to ignore the agent in this collision check, set ignoreAgent to true
-        protected bool isHandObjectColliding(bool ignoreAgent = false, List<GameObject> ignoreGameObjects = null, float expandBy = 0.0f) {
+        protected bool isHandObjectColliding(bool ignoreAgent = false, float expandBy = 0.0f) {
             if (ItemInHand == null) {
                 return false;
             }
-
-            if(ignoreGameObjects == null) {
-                ignoreGameObjects = new List<GameObject>();
-            }
-
+            List<GameObject> ignoreGameObjects = new List<GameObject>();
             // Ignore the agent when determining if the hand object is colliding
-            if (ignoreAgent && !ignoreGameObjects.Contains(this.gameObject)) {
+            if (ignoreAgent) {
                 ignoreGameObjects.Add(this.gameObject);
             }
             return UtilityFunctions.isObjectColliding(ItemInHand, ignoreGameObjects, expandBy);

--- a/unity/Assets/Scripts/UtilityFunctions.cs
+++ b/unity/Assets/Scripts/UtilityFunctions.cs
@@ -67,10 +67,13 @@ public static class UtilityFunctions {
                 }
             }
         }
+
         foreach (BoxCollider bc in go.GetComponentsInChildren<BoxCollider>()) {
-            foreach (Collider c in PhysicsExtensions.OverlapBox(bc, layerMask, QueryTriggerInteraction.Ignore, expandBy)) {
-                if (!ignoreColliders.Contains(c)) {
-                    return true;
+            if (!(bc.isTrigger && bc.tag.Equals("Receptacle"))) {
+                foreach (Collider c in PhysicsExtensions.OverlapBox(bc, layerMask, QueryTriggerInteraction.Ignore, expandBy)) {
+                    if (!ignoreColliders.Contains(c)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/unity/Assets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
+++ b/unity/Assets/Standard Assets/Characters/FirstPersonCharacter/Prefabs/FPSController.prefab
@@ -36,6 +36,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0.9010001, z: -1.75}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 4781144330620476}
+  - {fileID: 4044070813507312}
   - {fileID: 400002}
   - {fileID: 256261900933697180}
   - {fileID: 4372852436466418}
@@ -104,6 +106,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   InputFieldObj: {fileID: 0}
   PhysicsController: {fileID: 0}
+  continuous: 1
+  forceAction: 0
+  gridSize: 0.1
+  visibilityDistance: 0.4
+  moveOrPickupObjectDirection: {x: 0, y: 0, z: 0}
+  moveOrPickupObjectId: 
+  receptacleObjectDirection: {x: 0, y: 0, z: 0}
+  receptacleObjectId: 
+  rotationIncrement: 45
+  horizonIncrement: 30
+  pushPullForce: 150
+  FlyMagnitude: 1
+  WalkMagnitude: 0.2
   InputMode_Text: {fileID: 0}
 --- !u!114 &114000010621761404
 MonoBehaviour:
@@ -158,7 +173,6 @@ MonoBehaviour:
   VisibilityCapsule: {fileID: 1762015268591634}
   TallVisCap: {fileID: 256261900933697183}
   BotVisCap: {fileID: 1762015268591634}
-  currentAgentMode: 0
   agentManager: {fileID: 0}
   excludeObjectIds: []
   m_Camera: {fileID: 0}
@@ -283,7 +297,6 @@ MonoBehaviour:
   VisibilityCapsule: {fileID: 0}
   TallVisCap: {fileID: 0}
   BotVisCap: {fileID: 0}
-  currentAgentMode: 0
   agentManager: {fileID: 0}
   excludeObjectIds: []
   m_Camera: {fileID: 0}
@@ -359,12 +372,10 @@ Transform:
   m_LocalPosition: {x: 0, y: -0.0705, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 4044070813507312}
-  - {fileID: 4781144330620476}
   - {fileID: 4215455022293814}
   - {fileID: 4405666214316280}
   m_Father: {fileID: 400000}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &2000000
 Camera:
@@ -2091,12 +2102,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1340499340313870}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: -0.16, z: 0.38}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.23049998, z: 0.38}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 400002}
-  m_RootOrder: 0
+  m_Father: {fileID: 400000}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &33880031027872102
 MeshFilter:
@@ -2888,7 +2899,7 @@ Transform:
   - {fileID: 4338381025073618}
   - {fileID: 4976430470828868}
   m_Father: {fileID: 400002}
-  m_RootOrder: 3
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1705092847067678
 GameObject:
@@ -3043,7 +3054,7 @@ Transform:
   m_Children:
   - {fileID: 4097500997184042582}
   m_Father: {fileID: 400000}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1762336587455144
 GameObject:
@@ -3285,12 +3296,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1863262018947090}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: -0.16, z: 0.38}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.23049998, z: 0.38}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 400002}
-  m_RootOrder: 1
+  m_Father: {fileID: 400000}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1890475479083370
 GameObject:
@@ -3332,7 +3343,7 @@ Transform:
   - {fileID: 4376361339554026}
   - {fileID: 4373494218293124}
   m_Father: {fileID: 400002}
-  m_RootOrder: 2
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1908917868031352
 GameObject:
@@ -4728,7 +4739,7 @@ Transform:
   m_Children:
   - {fileID: 256261899978608359}
   m_Father: {fileID: 400000}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &256261901085417433
 GameObject:


### PR DESCRIPTION
- Ignoring collisions in isObjectColliding (called by DropObject) for ReceptacleTriggerBoxes, since they're not needed and those types of colliders can vary greatly in size
- Hand is now at top level, not camera level for the FPSController, so that the agent hand/objects in the agent's hand stay in front of the agent, and don't start clipping with the agent when rotating the camera towards the floor

