### PR TITLE
MCS-282 - Fix issues with object scaling

### DIFF
--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -597,8 +597,8 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             // once held, never collides with the player's body.
             float handZ = (meshFilter.mesh.bounds.size.z / 2.0f * meshFilter.transform.localScale.z);
             if (!GameObject.ReferenceEquals(meshFilter.gameObject, target.gameObject)) {
-                handY = (handY + (meshFilter.transform.localPosition.y * meshFilter.transform.localScale.y));
-                handZ = ((handZ - meshFilter.transform.localPosition.z) * target.gameObject.transform.localScale.z);
+                handY = (handY * target.gameObject.transform.localScale.y) + (meshFilter.transform.localPosition.y * meshFilter.transform.localScale.y);
+                handZ = (handZ * target.gameObject.transform.localScale.z) - (meshFilter.transform.localPosition.z * meshFilter.transform.localScale.z);
             }
             this.AgentHand.transform.localPosition = new Vector3(this.AgentHand.transform.localPosition.x,
                 (handY + MCSController.DISTANCE_HELD_OBJECT_Y) * -1,


### PR DESCRIPTION
The original ticket was for the reward not being calculated correctly for transferral_goal-0090.json, but the underlying issue was the dropped object fell through the floor, because it was placed under the floor when picked up. This was due to an issue with object scale not being accounted for correctly in this case (thanks for the help @ThomasSchellenbergNextCentury). Retested with transferral_goal-0090 -- looks like goal success registers correctly now. Also tested scale fix with a few other objects (plate/block/box/cup/duck). 

I will leave a note on that ticket as well, in case a separate issue exists with reward calculation so there's no confusion!