### PR TITLE
MCS-313

### DIFF
--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2069,10 +2069,10 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.27
-  m_Height: 1.4
+  m_Radius: 0.05
+  m_Height: 0.925
   m_Direction: 1
-  m_Center: {x: 0, y: -0.375, z: 0}
+  m_Center: {x: 0, y: -0.4625, z: 0}
 --- !u!1 &513116322 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1762015268591634, guid: 5e9e851c0e142814dac026a256ba2ac0,
@@ -3196,6 +3196,7 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 114749714472260818, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
     - {fileID: 2433281640897831673, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
+    - {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
 --- !u!1 &1752557969 stripped
 GameObject:
@@ -3397,7 +3398,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 940f8586c495e37cc80926a37e932c65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSceneFile: 
+  defaultSceneFile: playroom
   enableVerboseLog: 0
   ai2thorObjectRegistryFile: ai2thor_object_registry
   mcsObjectRegistryFile: mcs_object_registry

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2059,20 +2059,6 @@ MonoBehaviour:
     m_Extent: {x: -Infinity, y: -Infinity, z: -Infinity}
   step: 0
   fpsAgent: {fileID: 1752557969}
---- !u!136 &506323130
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 506323128}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.27
-  m_Height: 1.3875
-  m_Direction: 1
-  m_Center: {x: 0, y: -0.4625, z: 0}
 --- !u!1 &513116322 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1762015268591634, guid: 5e9e851c0e142814dac026a256ba2ac0,
@@ -3129,17 +3115,22 @@ PrefabInstance:
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: m_Center.y
-      value: -0.25
+      value: -0.4625
       objectReference: {fileID: 0}
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: m_Radius
-      value: 0.05
+      value: 0.27
       objectReference: {fileID: 0}
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: m_Height
-      value: 0.05
+      value: 1.3875
+      objectReference: {fileID: 0}
+    - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 14300000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
       propertyPath: m_Center.y
@@ -3196,7 +3187,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 114749714472260818, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
     - {fileID: 2433281640897831673, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
-    - {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
 --- !u!1 &1752557969 stripped
 GameObject:

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2069,7 +2069,7 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.05
+  m_Radius: 0.27
   m_Height: 0.925
   m_Direction: 1
   m_Center: {x: 0, y: -0.4625, z: 0}
@@ -3398,7 +3398,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 940f8586c495e37cc80926a37e932c65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSceneFile: playroom
+  defaultSceneFile: 
   enableVerboseLog: 0
   ai2thorObjectRegistryFile: ai2thor_object_registry
   mcsObjectRegistryFile: mcs_object_registry

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2070,7 +2070,7 @@ CapsuleCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   m_Radius: 0.27
-  m_Height: 0.925
+  m_Height: 1.3875
   m_Direction: 1
   m_Center: {x: 0, y: -0.4625, z: 0}
 --- !u!1 &513116322 stripped

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -696,7 +696,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         Vector3 origin = new Vector3(transform.position.x, startHeight, transform.position.z);
         Vector3 end = new Vector3(transform.position.x, endHeight, transform.position.z);
         RaycastHit hit;
-        Ray ray = new Ray(origin, direction);
         LayerMask layerMask = ~(1 << 10);
         
         //if raycast hits an object, the agent does not move on y-axis

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -9,10 +9,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     public static float STANDING_POSITION_Y = 0.4625f;
     public static float CRAWLING_POSITION_Y = STANDING_POSITION_Y/2;
     public static float LYING_POSITION_Y = 0.1f;
-    public static float STANDING_POSITION_COLLIDER_CENTER = -0.25f;
-    public static float CRAWLING_POSITION_COLLIDER_CENTER = -0.10f;
-    public static float LYING_POSITION_COLLIDER_CENTER = 0f;
-
+    
     public static float DISTANCE_HELD_OBJECT_Y = 0.15f;
     public static float DISTANCE_HELD_OBJECT_Z = 0.20f;
 
@@ -659,7 +656,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         } else {
             float startHeight = (this.pose == PlayerPose.LYING ? LYING_POSITION_Y : STANDING_POSITION_Y);
             Vector3 direction = (this.pose == PlayerPose.LYING ? Vector3.up : Vector3.down);
-            CheckIfAgentCanCrawlLieOrStand(direction, startHeight, CRAWLING_POSITION_Y, CRAWLING_POSITION_COLLIDER_CENTER, PlayerPose.CRAWLING);  
+            CheckIfAgentCanCrawlLieOrStand(direction, startHeight, CRAWLING_POSITION_Y, PlayerPose.CRAWLING);  
         }
     }
     
@@ -670,7 +667,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             Debug.Log("Agent is already Lying Down");
         } else {
             float startHeight = (this.pose == PlayerPose.CRAWLING ? CRAWLING_POSITION_Y : STANDING_POSITION_Y);
-            CheckIfAgentCanCrawlLieOrStand(Vector3.down, startHeight, LYING_POSITION_Y, LYING_POSITION_COLLIDER_CENTER, PlayerPose.LYING);              
+            CheckIfAgentCanCrawlLieOrStand(Vector3.down, startHeight, LYING_POSITION_Y, PlayerPose.LYING);              
         }
 
         
@@ -687,11 +684,11 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             Debug.Log("Agent cannot Stand when lying down");
         } else {
             float startHeight = (this.pose == PlayerPose.CRAWLING ? CRAWLING_POSITION_Y : LYING_POSITION_Y);
-            CheckIfAgentCanCrawlLieOrStand(Vector3.up, startHeight, STANDING_POSITION_Y, STANDING_POSITION_COLLIDER_CENTER, PlayerPose.STANDING); 
+            CheckIfAgentCanCrawlLieOrStand(Vector3.up, startHeight, STANDING_POSITION_Y, PlayerPose.STANDING); 
         }
     }
 
-    public void CheckIfAgentCanCrawlLieOrStand(Vector3 direction, float startHeight, float endHeight, float colliderY, PlayerPose pose) {
+    public void CheckIfAgentCanCrawlLieOrStand(Vector3 direction, float startHeight, float endHeight, PlayerPose pose) {
         //Raycast up or down the distance of shifting on y-axis
         Vector3 origin = new Vector3(transform.position.x, startHeight, transform.position.z);
         Vector3 end = new Vector3(transform.position.x, endHeight, transform.position.z);
@@ -711,9 +708,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             SetUpRotationBoxChecks();
             this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
             actionFinished(true);
-
-            //change collider height so agent can move
-            GetComponent<CapsuleCollider>().center = new Vector3(0, colliderY, 0);
         }
     }
 

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2706,7 +2706,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         if ((res.transform.tag == "Structure" && isStructure) || 
                             (res.rigidbody.mass > this.GetComponent<Rigidbody>().mass && res.transform.tag == "SimObjPhysics"))
                         {
-                            Debug.Log("STRUCT");
                             int thisAgentNum = agentManager.agents.IndexOf(this);
                             errorMessage = res.transform.name + " is blocking Agent " + thisAgentNum.ToString() + " from moving " + orientation;
                             //the moment we find a result that is blocking, return false here

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -6875,7 +6875,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (Physics.SphereCast(point1, cc.radius, Vector3.down, out hit, Mathf.Infinity, layerMask2)) 
             {
-                point2.y = hit.point.y + radius + 0.01f;
+                float raiseMinHeightAboveGround = 0.01f;
+                point2.y = hit.point.y + radius + raiseMinHeightAboveGround;
             }
 
             return Physics.CapsuleCastAll(


### PR DESCRIPTION
https://nextcentury.atlassian.net/browse/MCS-313

The radius is still 0.27, when its 0.05 collisions do not look great and behave differently. The collisions are not usually continuous because there is not much surface area and it looks like the agent is going through objects. 

I wanted to remove the y-collider height changes for poses since I changed how the collider detects if it can move. The height of the collider is now 2.5 times the center y so that it still works when lying down and doesn't need to be moved with every pose change. 

The 0.01f is a very slight height increase that ensures the collider is not in the floor when crouching and lying down. It needs to be there. If you feel it should be static or constant I will do that, but I did not think it needed to be.

*Look at 104 comments!