### PR TITLE
MCS-387 - Option to randomize segmentation mask colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,6 @@ unity/Assets/Resources/MCS/UnityAssetStore/*
 unity/Assets/Resources/MCS/UnityAssetStore.meta
 unity/Assets/_TerrainAutoUpgrade.meta
 unity/Assets/_TerrainAutoUpgrade/
+unity/*.app/
+Unity/*.data
 

--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,5 @@ unity/Assets/Resources/MCS/UnityAssetStore.meta
 unity/Assets/_TerrainAutoUpgrade.meta
 unity/Assets/_TerrainAutoUpgrade/
 unity/*.app/
-Unity/*.data
+unity/*.data
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
   - Created the `InitializeForm` and `FinalizeMultiAgentMetadata` virtual functions and called them both inside `EmitFrame`
   - Changed `readyToEmit = true;` to `this.setReadyToEmit(true);` in `addAgents`, `ProcessControlCommand`, `Start`
   - Added Object Types: `Hollow`
+  - Added property `consistentColors`
 - `Scripts/BaseFPSAgentController`:
   - Added `virtual` to functions: `Initialize`, `ProcessControlCommand`
   - Removed the hard-coded camera properties in the `SetAgentMode` function
@@ -268,5 +269,6 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
 - `ImageSynthesis/ImageSynthesis`:
   - Added a null check in `OnSceneChange`
   - Changed to always use the `Hidden/Depth` Shader
+  - Added property `guidForColors` and way to update it (`UpdateGuidForColors`). This is used to create random colors for object masks in `OnSceneChange`
 - `ImageSynthesis/Shaders/Depth`:
   - Changed the `frag` function to return pixels based on the camera's far clipping pane

--- a/unity/Assets/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/ImageSynthesis/ImageSynthesis.cs
@@ -76,7 +76,7 @@ public class ImageSynthesis : MonoBehaviour {
 	public Texture2D tex;
 
 	// If needed, use a guid to generate unique segmentation mask colors for each step
-	private string guidForColors = "";
+	private string guidForColors = string.Empty;
 
 	void Start()
 	{
@@ -284,7 +284,7 @@ public class ImageSynthesis : MonoBehaviour {
 		if(!consistentColors) {
 			this.guidForColors = System.Guid.NewGuid().ToString();
 		} else {
-			this.guidForColors = "";
+			this.guidForColors = string.Empty;
         }
 	}
 

--- a/unity/Assets/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/ImageSynthesis/ImageSynthesis.cs
@@ -75,6 +75,9 @@ public class ImageSynthesis : MonoBehaviour {
 
 	public Texture2D tex;
 
+	// If needed, use a guid to generate unique segmentation mask colors for each step
+	private string guidForColors = "";
+
 	void Start()
 	{
 		//XXXXXXXXXXX************
@@ -274,6 +277,14 @@ public class ImageSynthesis : MonoBehaviour {
 		}
 	}
 
+	// If we need to generate random colors for segmentation masks, update color
+	// guid before calling OnSceneChange (which will recreate the colorsIds
+	// dictionary)
+	public void UpdateGuidForColors(bool consistentColors) {
+		if(!consistentColors) {
+			this.guidForColors = System.Guid.NewGuid().ToString();
+		}
+	}
 
 	public void OnSceneChange()
 	{
@@ -317,7 +328,7 @@ public class ImageSynthesis : MonoBehaviour {
 			Color classColor;
 			Color objColor;
 			classColor = ColorEncoding.EncodeTagAsColor (classTag);
-			objColor = ColorEncoding.EncodeTagAsColor(objTag);
+			objColor = ColorEncoding.EncodeTagAsColor(objTag + guidForColors);
 
             if (capturePasses[0].camera != null) {
 			    capturePasses [0].camera.WorldToScreenPoint (r.bounds.center);

--- a/unity/Assets/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/ImageSynthesis/ImageSynthesis.cs
@@ -283,7 +283,9 @@ public class ImageSynthesis : MonoBehaviour {
 	public void UpdateGuidForColors(bool consistentColors) {
 		if(!consistentColors) {
 			this.guidForColors = System.Guid.NewGuid().ToString();
-		}
+		} else {
+			this.guidForColors = "";
+        }
 	}
 
 	public void OnSceneChange()

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -135,6 +135,7 @@ MonoBehaviour:
   renderImage: 1
   actionDuration: 3
   AdvancePhysicsStepCount: 0
+  consistentColors: 0
 --- !u!114 &14088545
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -44,6 +44,7 @@ public class AgentManager : MonoBehaviour
 
     protected PhysicsSceneManager physicsSceneManager;
     public int AdvancePhysicsStepCount = 0;
+	public bool consistentColors = false;
 
 	void Awake() {
 
@@ -124,6 +125,7 @@ public class AgentManager : MonoBehaviour
 		this.renderNormalsImage = action.renderNormalsImage;
 		this.renderObjectImage = action.renderObjectImage;
         this.renderFlowImage = action.renderFlowImage;
+
 		if (action.alwaysReturnVisibleRange) {
 			((PhysicsRemoteFPSAgentController) primaryAgent).alwaysReturnVisibleRange = action.alwaysReturnVisibleRange;
 		}
@@ -463,8 +465,9 @@ public class AgentManager : MonoBehaviour
 				cid.name = agent.imageSynthesis.colorIds [key];
 				colors.Add (cid);
 			}
+
 			metadata.colors = colors.ToArray ();
-        }
+		}
         return metadata;
 	}
 
@@ -714,6 +717,7 @@ public class AgentManager : MonoBehaviour
 		this.currentSequenceId = controlCommand.sequenceId;
 		this.renderImage = controlCommand.renderImage;
 		activeAgentId = controlCommand.agentId;
+
 		if (controlCommand.action == "Reset") {
 			this.Reset (controlCommand);
 		} else if (controlCommand.action == "Initialize") {
@@ -1061,6 +1065,7 @@ public class ServerAction
     public Vector3 objectDirection;
     public Vector3 receptacleObjectDirection;
     public MCSConfigScene sceneConfig;
+	public bool consistentColors = false;
 
     public SimObjType ReceptableSimObjType()
 	{

--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -23,6 +23,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
         public float pushPullForce = 150.0f;
         public float FlyMagnitude = 1.0f;
         public float WalkMagnitude = 0.2f;
+        public bool consistentColors = false;
 
         [SerializeField] private GameObject InputMode_Text = null;
         // Start is called before the first frame update
@@ -47,6 +48,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             action.action = "Initialize";
             action.gridSize = gridSize;
             action.visibilityDistance = visibilityDistance;
+            action.consistentColors = consistentColors;
             PhysicsController.ProcessControlCommand(action);
         }
 

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -202,7 +202,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         this.agentManager.consistentColors = action.consistentColors;
         if (this.imageSynthesis != null && this.imageSynthesis.enabled) {
             this.imageSynthesis.UpdateGuidForColors(this.agentManager.consistentColors);
-            this.imageSynthesis.OnSceneChange();
         }
         base.Initialize(action);
 

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -198,6 +198,12 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     }
 
     public override void Initialize(ServerAction action) {
+        // Randomize segmentation mask colors if required
+        this.agentManager.consistentColors = action.consistentColors;
+        if (this.imageSynthesis != null && this.imageSynthesis.enabled) {
+            this.imageSynthesis.UpdateGuidForColors(this.agentManager.consistentColors);
+            this.imageSynthesis.OnSceneChange();
+        }
         base.Initialize(action);
 
         this.step = 0;

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -198,11 +198,8 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     }
 
     public override void Initialize(ServerAction action) {
-        // Randomize segmentation mask colors if required
+        // Set consistentColors to randomize segmentation mask colors if required
         this.agentManager.consistentColors = action.consistentColors;
-        if (this.imageSynthesis != null && this.imageSynthesis.enabled) {
-            this.imageSynthesis.UpdateGuidForColors(this.agentManager.consistentColors);
-        }
         base.Initialize(action);
 
         this.step = 0;

--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -114,6 +114,12 @@ public class MCSMain : MonoBehaviour {
             this.lastStep++;
             Debug.Log("MCS: Run Step " + this.lastStep + " at Frame " + Time.frameCount);
             if (this.currentScene != null && this.currentScene.objects != null) {
+                // update segmentation mask colors
+                ImageSynthesis imageSynthesis = GameObject.Find("FPSController").GetComponentInChildren<ImageSynthesis>();
+                if (imageSynthesis != null && imageSynthesis.enabled) {
+                    imageSynthesis.UpdateGuidForColors(this.agentController.agentManager.consistentColors);
+                    imageSynthesis.OnSceneChange();
+                }
                 bool objectsWereShown = false;
                 List<MCSConfigGameObject> objects = this.currentScene.objects.Where(objectConfig =>
                     objectConfig.GetGameObject() != null).ToList();
@@ -130,8 +136,6 @@ public class MCSMain : MonoBehaviour {
                     // Notify the PhysicsSceneManager so the objects will be compatible with AI2-THOR scripts.
                     this.physicsSceneManager.SetupScene();
                     // Notify ImageSynthesis so the objects will appear in the masks.
-                    ImageSynthesis imageSynthesis = GameObject.Find("FPSController")
-                        .GetComponentInChildren<ImageSynthesis>();
                     if (imageSynthesis != null && imageSynthesis.enabled) {
                         imageSynthesis.OnSceneChange();
                     }
@@ -330,6 +334,7 @@ public class MCSMain : MonoBehaviour {
 
         this.lastStep = -1;
         this.physicsSceneManager.SetupScene();
+        
     }
 
     private Collider AssignBoundingBox(


### PR DESCRIPTION
Associated MCS changes here: https://github.com/NextCenturyCorporation/MCS/pull/188

Some of the trouble with this ticket was getting the behavior to act the same way within the Unity Editor as it does in the Python API. ~~The only discrepancy left is: within the Unity Editor, running with consistentColors set to true never changes the colors from different runs of a scene, but through the Python API, colors are randomized once at the beginning (but stay consistent during that run). Shouldn't matter too much, but thought it was worth mentioning.~~ (Update: this has been fixed). 