### PR TITLE
MCS-346 Changed depth shader to return more depth data. Changed far clipping plane to 15.

### DIFF
--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -3045,7 +3045,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2000000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
       propertyPath: far clip plane
-      value: 25
+      value: 15
       objectReference: {fileID: 0}
     - target: {fileID: 2000000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
       propertyPath: m_NormalizedViewPortRect.width
@@ -3078,6 +3078,10 @@ PrefabInstance:
     - target: {fileID: 2000000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
       propertyPath: m_BackGroundColor.a
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2000000, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
+      propertyPath: near clip plane
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 100002, guid: 5e9e851c0e142814dac026a256ba2ac0, type: 3}
       propertyPath: m_IsActive


### PR DESCRIPTION
(Same description as Python PR)

I've changed the data returned by the Unity depth shader. Previously, the distance from 0 to 25 units was divided among 255 pixels, so each pixel represents about 0.1 unit. Now, I've reduced the far clipping plane to 15 units, and I've split the distance into three sets of 5 units, and each element in the RGB pixel corresponds to one set of 5 units, so each pixel represents about 0.02 unit. This is the best I can do limited to pixel (int) data.

I've tried using the original AI2-THOR code and can't get it to work properly, even after looking at some changes that the AI2-THOR team made after we forked. I'm not convinced that their code works in a way that's useful to us.

Additionally, I can't figure out how to get Unity to return anything other than pixel (int) arrays, which limits what we can give to the TA1s. I'm not sure if it's a problem with the shader itself, or the overly-complicated C# code, or something else. Hopefully this is something our Unity developer can eventually tackle. In the meantime, hopefully my solution here will stop people from complaining ON A DAILY BASIS.

Corresponding Python PR: https://github.com/NextCenturyCorporation/MCS/pull/192