### PR TITLE
Depth shader

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,10 @@ Note for Linux developers: The AI2-THOR v2.2.0 documetation instructs us to use 
 Note that while installing and/or launching Unity, you may get an error about `libgconf-2.so.4`.  You should be able to solve this issue by `sudo apt install`-ing the library.
 
 1. Download the `2018.3.0f2` "Official Installer" from the Unity Linux Editor forums [here](https://forum.unity.com/threads/unity-on-linux-release-notes-and-known-issues.350256/page-2#post-4009651).  The download is called `UnitySetup-2018.3.0f2`.
-
 2. Run the `UnitySetup-2018.3.0f2` executable (you may need to `chmod` it).  This should install a `Unity-2018.3.0f2` folder.
-
 3. In `Unity-2018.3.0f2/Editor/` run the `Unity` executable to start the Unity Hub.
-
 4. Enter your MCS Unity License info into the Unity Hub.
-
 5. In the Unity Hub, under the Projects tab, click Open and select the `/unity/` folder in your local clone of this repository.  This should add a "unity" project to your Projects list.
-
 6. Double-click the "unity" project to launch the Unity Editor.  See [Run](#run) below for usage information.  Please note that the initial load of this project in the Unity Editor will take a long time.
 
 ### Assets
@@ -35,20 +30,17 @@ Checkout the [MCS private GitHub repository](https://github.com/NextCenturyCorpo
 If you want to run an MCS Scene in the Unity Editor:
 
 1. Open the MCS Scene: `File->Open Scene` then select `Assets/Scenes/MCS.unity`
-
 2. By default, in the Unity Editor, see the Hierarchy window on the left, the Scene and Game windows in the middle, the Inspector window on the right, and the Project and Console windows at the bottom.
-  - The Hierarchy window lists the Game Objects in the Scene.
-  - The Scene and Game windows show the Scene.
-  - The Inspector window lists the properties, scripts, materials, and other components of the selected Game Object.
-  - The Project window shows the files in the current project.
-  - The Console window shows the logs and errors.
+
+- The Hierarchy window lists the Game Objects in the Scene.
+- The Scene and Game windows show the Scene.
+- The Inspector window lists the properties, scripts, materials, and other components of the selected Game Object.
+- The Project window shows the files in the current project.
+- The Console window shows the logs and errors.
 
 3. To successfully run an MCS Scene, copy a JSON scene configuration file from the [scenes folder in our MCS GitHub repository](https://github.com/NextCenturyCorporation/MCS/tree/master/python_api/scenes) into the [`unity/Assets/Resources/MCS/Scenes/`](./unity/Assets/Resources/MCS/Scenes/) folder, or identify a JSON file in the folder to use (like `playroom.json`).
-
 4. Click on the `MCS` Game Object in the Hierarchy window. Then, in the Inspector Window, under the `MCS Main (Script)` component, enter the name of your selected JSON file in the `"Default Scene File"` property WITHOUT the `.json` extension.
-
 5. If you want to see the class/depth/object masks, click on the `FPSController->FirstPersonCharacter` Game Object in the Hierarchy window, then toggle-on the checkbox next to the `Image Synthesis (Script)` component in the Inspector window to activate that script. You can see the masks during a run using the Display dropdown in the Game window.
-
 6. Click the Play button in the top center of the Unity Editor to run the Scene. See the list of [keys and parameters](#keys-and-parameters) below. To set action parameters, click the `FPSController` Game Object in the Hierarchy window, then use the inputs under `Debug Discrete Agent Controller (Script)`. See [`unity/Assets/Scripts/DebugDiscreteAgentController.cs`](./unity/Assets/Scripts/DebugDiscreteAgentController.cs) for additional key bindings.
 
 #### Keys and Parameters
@@ -114,9 +106,9 @@ tar -czvf MCS-AI2-THOR-Unity-App-<version>_Data.tar.gz MCS-AI2-THOR-Unity-App-<v
 - [`unity/Assets/Scripts/MachineCommonSensePerformerManager.cs`](./unity/Assets/Scripts/MachineCommonSensePerformerManager.cs)  A custom subclass extending AI2-THOR's [AgentManager](./unity/Assets/Scripts/AgentManager.cs) that handles the communication between the Python API and the Unity Scene.
 - [`unity/Assets/Scripts/MachineCommonSenseSceneManager.cs`](./unity/Assets/Scripts/MachineCommonSenseSceneManager.cs)  A custom subclass extending AI2-THOR's [PhysicsSceneManager](./unity/Assets/Scripts/PhysicsSceneManager.cs) that handles scene state.
 - [`unity/Assets/Resources/MCS/`](./unity/Assets/Resources/MCS)  Folder containing all MCS runtime resources.
-- [`unity/Assets/Resources/MCS/ai2thor_object_registry.json`](./unity/Assets/Resources/MCS/ai2thor_object_registry.json)  Config file containing the MCS Scene's specific Game Objects borrowed from the AI2-THOR framework that may be loaded at runtime. 
-- [`unity/Assets/Resources/MCS/mcs_object_registry.json`](./unity/Assets/Resources/MCS/mcs_object_registry.json)  Config file containing the MCS Scene's specific custom Game Objects that may be loaded at runtime. 
-- [`unity/Assets/Resources/MCS/primitive_object_registry.json`](./unity/Assets/Resources/MCS/primitive_object_registry.json)  Config file containing the MCS Scene's Unity Primitive Game Objects that may be loaded at runtime. 
+- [`unity/Assets/Resources/MCS/ai2thor_object_registry.json`](./unity/Assets/Resources/MCS/ai2thor_object_registry.json)  Config file containing the MCS Scene's specific Game Objects borrowed from the AI2-THOR framework that may be loaded at runtime.
+- [`unity/Assets/Resources/MCS/mcs_object_registry.json`](./unity/Assets/Resources/MCS/mcs_object_registry.json)  Config file containing the MCS Scene's specific custom Game Objects that may be loaded at runtime.
+- [`unity/Assets/Resources/MCS/primitive_object_registry.json`](./unity/Assets/Resources/MCS/primitive_object_registry.json)  Config file containing the MCS Scene's Unity Primitive Game Objects that may be loaded at runtime.
 - [`unity/Assets/Resources/MCS/Materials/`](./unity/Assets/Resources/MCS/Materials)  Copy of AI2-THOR's [`unity/Assets/QuickMaterials/`](./unity/Assets/QuickMaterials).  Must be in the `Resources` folder to access at runtime.
 - [`unity/Assets/Resources/MCS/Scenes/`](./unity/Assets/Resources/MCS/Scenes)  Folder containing sample scene config files (see [Run](#run)).
 
@@ -272,6 +264,8 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
 - `ImageSynthesis/ImageSynthesis`:
   - Added a null check in `OnSceneChange`
   - Changed to always use the `Hidden/Depth` Shader
+  - Modified `Hidden/Depth` Shader to use turbo shading techniques
+  - Added editor controls to change depth power ratio and far clipping plane
   - Added property `guidForColors` and way to update it (`UpdateGuidForColors`). This is used to create random colors for object masks in `OnSceneChange`
 - `ImageSynthesis/Shaders/Depth`:
   - Changed the `frag` function to return pixels based on the camera's far clipping pane

--- a/unity/Assets/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/ImageSynthesis/ImageSynthesis.cs
@@ -67,8 +67,6 @@ public class ImageSynthesis : MonoBehaviour {
 
 	[Range(0.0f, 1.0f)]
 	public float depthPowerScale = 0.8f;
-	[Range(1f, 100f)]
-	public float depthFarClipPlane = 1.0f;
 	
 	private Dictionary<int, string> nonSimObjUniqueIds = new Dictionary<int, string>();
 
@@ -122,7 +120,6 @@ public class ImageSynthesis : MonoBehaviour {
 	{
 		if (depthMaterial != null)
 			depthMaterial.SetFloat("_DepthPower", depthPowerScale);
-		capturePasses[1].camera.farClipPlane = depthFarClipPlane;
 	}
 
 	void LateUpdate()
@@ -130,6 +127,10 @@ public class ImageSynthesis : MonoBehaviour {
 		#if UNITY_EDITOR
 		if (DetectPotentialSceneChangeInEditor())
 			OnSceneChange();
+
+		// verify that the depth shader camera and main camera far clip planes are the same
+		var mainCamera = GetComponent<Camera>();
+		capturePasses[1].camera.farClipPlane = mainCamera.farClipPlane;
 
 		#endif // UNITY_EDITOR
 
@@ -242,7 +243,6 @@ public class ImageSynthesis : MonoBehaviour {
 		
 		//capturePasses [1].camera.farClipPlane = 100;
 		//SetupCameraWithReplacementShader(capturePasses[1].camera, uberReplacementShader, ReplacelementModes.DepthMultichannel);
-		depthFarClipPlane = capturePasses[1].camera.farClipPlane;
 		depthMaterial.SetFloat("_DepthPower", depthPowerScale);
 		SetupCameraWithPostShader(capturePasses[1].camera, depthMaterial, DepthTextureMode.Depth);
 

--- a/unity/Assets/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/ImageSynthesis/ImageSynthesis.cs
@@ -65,6 +65,11 @@ public class ImageSynthesis : MonoBehaviour {
 
 	public float opticalFlowSensitivity;
 
+	[Range(0.0f, 1.0f)]
+	public float depthPowerScale = 0.8f;
+	[Range(1f, 100f)]
+	public float depthFarClipPlane = 1.0f;
+	
 	private Dictionary<int, string> nonSimObjUniqueIds = new Dictionary<int, string>();
 
 	// cached materials
@@ -111,6 +116,13 @@ public class ImageSynthesis : MonoBehaviour {
 		OnCameraChange();
 		OnSceneChange();
 
+	}
+
+	void OnValidate()
+	{
+		if (depthMaterial != null)
+			depthMaterial.SetFloat("_DepthPower", depthPowerScale);
+		capturePasses[1].camera.farClipPlane = depthFarClipPlane;
 	}
 
 	void LateUpdate()
@@ -227,8 +239,11 @@ public class ImageSynthesis : MonoBehaviour {
 		if (!depthMaterial || depthMaterial.shader != depthShader) {
 			depthMaterial = new Material (depthShader);	
 		}
+		
 		//capturePasses [1].camera.farClipPlane = 100;
 		//SetupCameraWithReplacementShader(capturePasses[1].camera, uberReplacementShader, ReplacelementModes.DepthMultichannel);
+		depthFarClipPlane = capturePasses[1].camera.farClipPlane;
+		depthMaterial.SetFloat("_DepthPower", depthPowerScale);
 		SetupCameraWithPostShader(capturePasses[1].camera, depthMaterial, DepthTextureMode.Depth);
 
 

--- a/unity/Assets/ImageSynthesis/Shaders/Depth.shader
+++ b/unity/Assets/ImageSynthesis/Shaders/Depth.shader
@@ -1,26 +1,29 @@
 // Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+// Upgrade NOTE: updated the depth shader to use a TurboColorMap to display a spectrum
+//               of colors to represent distance from the camera.
 
 Shader "Hidden/Depth" {
      Properties
      {
-         _MainTex ("Base (RGB)", 2D) = "white" {}
-         _DepthLevel ("Depth Level", Range(1, 3)) = 1
+     	 // Depth power of 1 sets it so the spectrum of colors is linear from the camera's near to far clipping
+     	 // plane. The closer the value is to 0 sets allocates more room in the spectrum to closer objects.
+     	 _DepthPower ("Depth Power", Range(0, 1)) = 0.8
      }
      SubShader
      {
          Pass
          {
              CGPROGRAM
+			// Upgrade NOTE: excluded shader from DX11, OpenGL ES 2.0 because it uses unsized arrays
+			#pragma exclude_renderers d3d11 gles
 
              #pragma vertex vert
              #pragma fragment frag
              #include "UnityCG.cginc"
 
-             uniform sampler2D _MainTex;
              uniform sampler2D _CameraDepthTexture;
-             uniform fixed _DepthLevel;
-             uniform half4 _MainTex_TexelSize;
-
+             uniform float _DepthPower;
+             
              struct input
              {
                  float4 pos : POSITION;
@@ -33,33 +36,42 @@ Shader "Hidden/Depth" {
                  half2 uv : TEXCOORD0;
              };
 
-
              output vert(input i)
              {
                  output o;
                  o.pos = UnityObjectToClipPos(i.pos);
-                 o.uv = MultiplyUV(UNITY_MATRIX_TEXTURE0, i.uv);
-                 // why do we need this? cause sometimes the image I get is flipped. see: http://docs.unity3d.com/Manual/SL-PlatformDifferences.html
-                 #if UNITY_UV_STARTS_AT_TOP
-                 if (_MainTex_TexelSize.y < 0)
-                         o.uv.y = 1 - o.uv.y;
-                 #endif
-
-                 return o;
+                 o.uv = i.uv;
+             	 return o;
              }
 
+             // Copyright 2019 Google LLC.
+			 // SPDX-License-Identifier: Apache-2.0
+			 // Original LUT: https://gist.github.com/mikhailov-work/ee72ba4191942acecc03fe6da94fc73f
+			float3 TurboColormap(float x)
+			{
+			    const float4 kRedVec4 = float4(0.13572138, 4.61539260, -42.66032258, 132.13108234);
+			    const float4 kGreenVec4 = float4(0.09140261, 2.19418839, 4.84296658, -14.18503333);
+			    const float4 kBlueVec4 = float4(0.10667330, 12.64194608, -60.58204836, 110.36276771);
+			    const float2 kRedVec2 = float2(-152.94239396, 59.28637943);
+			    const float2 kGreenVec2 = float2(4.27729857, 2.82956604);
+			    const float2 kBlueVec2 = float2(-89.90310912, 27.34824973);
+			    x = saturate(x);
+			    float4 v4 = float4(1.0, x, x * x, x * x * x);
+			    float2 v2 = v4.zw * v4.z;
+			    return float3(
+			        dot(v4, kRedVec4)   + dot(v2, kRedVec2),
+			        dot(v4, kGreenVec4) + dot(v2, kGreenVec2),
+			        dot(v4, kBlueVec4)  + dot(v2, kBlueVec2)
+			    );
+			}
+             
              float4 frag(output o) : COLOR
              {
-                 // LinearEyeDepth returns a value between the camera's near and far clipping planes.
-                 float depth = LinearEyeDepth(UNITY_SAMPLE_DEPTH(tex2D(_CameraDepthTexture, o.uv)));
-
-                 // Assume the far clipping plane is always 15.
-                 // Split the distance into three sets of 5, each corresponding to an RGB element.
-                 float low = min(5, depth) / 5.0;
-                 float mid = min(5, max(depth - 5, 0)) / 5.0;
-                 float high = min(5, max(depth - 10, 0)) / 5.0;
-                 return float4(low, mid, high, 0.0);
-             }
+				float depth = tex2D(_CameraDepthTexture, o.uv).r;
+				depth = Linear01Depth(depth);
+             	depth = pow(depth, _DepthPower);
+             	return float4(TurboColormap(depth), 1);
+			 }
 
              ENDCG
          }


### PR DESCRIPTION
Changed depth shader to use techniques described [here](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html). Exposed controls to change depth power (allows for higher sampling closer to the camera, 1.0 is a linear distribution) and depth camera's far clipping plane through Unity Editor UI. Updated readme.md changelog.