### PR TITLE
Added array serialization.

### DIFF
--- a/ai2thor/server.py
+++ b/ai2thor/server.py
@@ -33,6 +33,7 @@ werkzeug.serving.WSGIRequestHandler.protocol_version = 'HTTP/1.1'
 
 MAX_DEPTH = 5000
 
+
 # get with timeout to allow quit
 def queue_get(que):
     res = None
@@ -44,12 +45,16 @@ def queue_get(que):
             pass
     return res
 
+
 class NumpyAwareEncoder(json.JSONEncoder):
 
     def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
         if isinstance(obj, np.generic):
             return np.asscalar(obj)
         return super(NumpyAwareEncoder, self).default(obj)
+
 
 class BufferedIO(object):
     def __init__(self, wfile):
@@ -70,6 +75,7 @@ class BufferedIO(object):
     def closed(self):
         return self.wfile.closed
 
+
 class ThorRequestHandler(werkzeug.serving.WSGIRequestHandler):
     def run_wsgi(self):
         old_wfile = self.wfile
@@ -77,6 +83,7 @@ class ThorRequestHandler(werkzeug.serving.WSGIRequestHandler):
         result = super(ThorRequestHandler, self).run_wsgi()
         self.wfile = old_wfile
         return result
+
 
 class MultiAgentEvent(object):
 

--- a/ai2thor/tests/test_server.py
+++ b/ai2thor/tests/test_server.py
@@ -60,6 +60,7 @@ def test_multi_agent_train():
         input_stream=BytesIO(generate_multi_agent_form(metadata_simple, s.sequence_id)))
     assert res.status_code == 200
 
+
 def test_train_numpy_action():
     request_queue = Queue(maxsize=1)
     response_queue = Queue(maxsize=1)
@@ -68,6 +69,7 @@ def test_train_numpy_action():
         action='Teleport', 
         rotation=dict(y=np.array([24])[0]),
         moveMagnitude=np.array([55.5])[0],
+        myCustomArray=np.array([1, 2]),
     ))
 
     s = ai2thor.server.Server(request_queue, response_queue, '127.0.0.1')
@@ -78,8 +80,10 @@ def test_train_numpy_action():
         content_type='multipart/form-data; boundary=OVCo05I3SVXLPeTvCgJjHl1EOleL4u9TDx5raRVt',
         input_stream=BytesIO(generate_form(metadata_simple, s.sequence_id)))
     j = json.loads(res.get_data())
-    assert j == {'action': 'Teleport', 'rotation': {'y': 24}, 'sequenceId': 1, 'moveMagnitude': 55.5}
+    assert j == {'action': 'Teleport', 'rotation': {'y': 24}, 'sequenceId': 1, 'moveMagnitude': 55.5,
+                 'myCustomArray': [1, 2]}
     assert res.status_code == 200
+
 
 def test_train():
     request_queue = Queue(maxsize=1)


### PR DESCRIPTION
Since MCS still relies on this repository, this PR provides the equivalent of this [upstream PR](https://github.com/allenai/ai2thor/pull/587/files): It adds array serialization to the NumpyAwareEncoder without which external code using MCS like our Julia agent can break.