### PR TITLE
MCS-68 Fixed many little bugs discovered during integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,17 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
 - `Scripts/InstantiatePrefabTest`:
   - In `PlaceObject`, fixed object rotation so that it always rotates around the global DOWN rather than using the receptacle object's local rotation.
   - In `PlaceObject`, removed the `HowManyCornersToCheck` behavior because it was buggy (there's no way to guarantee that the 4 correct corners are always the 4 bottom corners).
+  - In `PlaceObject`, removed setting the object's rotation to the receptacle trigger box's rotation to keep the original rotation.
+  - In `PlaceObject`, in the `HowManyRotationsToCheck` loop, fixed setting the object's rotation to properly use euler angles.
+  - In `PlaceObject`, in the `ToCheck` loop, fixed setting the object's target position to handle objects with non-zero rotations.
   - In `CheckSpawnArea`, fixed how the object bounding box center and size are calculated so that its transform, its parent's transform, and its collider are all used.
 - `Scripts/PhysicsRemoteFPSAgentController`:
   - Changed variables or functions from `private` to `protected`: `physicsSceneManager`, `ObjectMetadataFromSimObjPhysics`
   - Added `virtual` to functions: `CloseObject`, `DropHandObject`, `OpenObject`, `PickupObject`, `PullObject`, `PushObject`, `PutObject`, `ResetAgentHandPosition`, `ThrowObject`, `ToggleObject`
   - Commented out a block in the `PickupObject` function that checked for collisions between the held object and other objects in the scene because it caused odd behavior if you were looking at the floor.  The `Look` functions don't make this check either, and we may decide not to move the held object during `Look` actions anyway.
   - In the `PlaceHeldObject` function: ignores `PlacementRestrictions` if `ObjType` is `IgnoreType`; sets the held object's parent to null so the parent's properties (like scale) don't affect the placement validation; sets the held object's `isKinematic` property to `false` if placement is successful.
+  - Added the `FindClosestPoint` function.
+  - In `ApplyForceObject` and `PickupObject`, use `FindClosestPoint` to decide whether an object is obstructed or just out-of-reach.
   - Added `lastActionStatus` to Move actions, as well as to `DropHandObject`, `PickupObject`, and `PutObject` to help indicate success or reason for failure
   - Added check to make sure object exists for `DropHandObject`
   - Make sure objectId specified is actually the object being held for `DropHandObject` and `PutObject`
@@ -257,6 +262,7 @@ Take a GameObject (we'll call it the "Target" object) containing a MeshFilter, M
   - Added properties: `shape`
   - Changed the `Start` function to `public` so we can call it from our scripts
   - Added `ApplyRelativeForce` to apply force in a direction relative to the agent's current position.
+  - In `FindMySpawnPoints`, ignore receptacle trigger boxes of stacking receptacles that are currently positioned higher than the receptacle itself (in case the receptacle is rotated).
 - `Scripts/SimObjType`:
   - Added `IgnoreType` to the `SimObjType` enum, `ReturnAllPoints`, and `AlwaysPlaceUpright`
   - Added `Stacking` to the `SimObjSecondaryProperty` enum.

--- a/unity/Assets/Resources/MCS/primitive_object_registry.json
+++ b/unity/Assets/Resources/MCS/primitive_object_registry.json
@@ -4,7 +4,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cone_03",
         "shape": "circle frustum",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.5,
             "y": 1,
@@ -103,7 +102,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cone_01",
         "shape": "cone",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.25,
             "y": 0.33,
@@ -202,7 +200,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cube_01",
         "shape": "cube",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 1,
             "y": 1,
@@ -295,7 +292,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cylinder_01",
         "shape": "cylinder",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.5,
             "y": 1,
@@ -631,7 +627,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/pyramid_01",
         "shape": "pyramid",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.7,
             "y": 1.4,
@@ -735,7 +730,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/sphere_06",
         "shape": "semi_sphere",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -844,7 +838,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/sphere_02",
         "shape": "sphere",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.5,
             "y": 0.5,
@@ -957,7 +950,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cube_05",
         "shape": "square frustum",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 1,
             "y": 0.66,
@@ -1056,7 +1048,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cube_08",
         "shape": "triangular prism",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 1,
             "y": 1,
@@ -1127,7 +1118,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/pipe_02",
         "shape": "tube narrow",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.5,
             "y": 1,
@@ -1691,7 +1681,6 @@
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/pipe_03",
         "shape": "tube wide",
         "mass": 1,
-        "pickupable": true,
         "scale": {
             "x": 0.5,
             "y": 1,

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -132,6 +132,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public enum ActionStatus
         {
+            CANNOT_ROTATE,
             HAND_IS_FULL,
             IS_CLOSED_COMPLETELY,
             IS_OPENED_COMPLETELY,

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -132,21 +132,22 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         public enum ActionStatus
         {
-			HAND_IS_FULL,
-			IS_CLOSED_COMPLETELY,
-			IS_OPENED_COMPLETELY,
-			NOT_HELD,
+            HAND_IS_FULL,
+            IS_CLOSED_COMPLETELY,
+            IS_OPENED_COMPLETELY,
+            NOT_HELD,
             NOT_INTERACTABLE,
-			NOT_OBJECT,
+            NOT_MOVEABLE,
+            NOT_OBJECT,
             NOT_OPENABLE,
-			NOT_PICKUPABLE,
-			NOT_RECEPTACLE,
-			OBSTRUCTED,
-			OUT_OF_REACH,
-			SUCCESSFUL,
-			SUCCESSFUL_WITH_INVALID_PARAMETERS,
+            NOT_PICKUPABLE,
+            NOT_RECEPTACLE,
+            OBSTRUCTED,
+            OUT_OF_REACH,
+            SUCCESSFUL,
+            SUCCESSFUL_WITH_INVALID_PARAMETERS,
             WRONG_POSE,
-			FAILED // generic error code for unexpected failures
+            FAILED // generic error code for unexpected failures
         }
 
 		public Quaternion TargetRotation

--- a/unity/Assets/Scripts/Contains.cs
+++ b/unity/Assets/Scripts/Contains.cs
@@ -479,9 +479,7 @@ public class Contains : MonoBehaviour
 
         SimObjPhysics simObj = gameObject.GetComponentInParent<SimObjPhysics>();
         if (simObj.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Stacking)) {
-			if (simObj.shape == "plate") //plates behave differently
-				return true;
-            return point.y >= (center.y - (size.y * 0.5f));
+            return true;
         }
 
         return point.x <= (center.x + (size.x * 0.5f)) && point.x >= (center.x - (size.x * 0.5f)) &&

--- a/unity/Assets/Scripts/MCSConfig.cs
+++ b/unity/Assets/Scripts/MCSConfig.cs
@@ -145,7 +145,9 @@ public class MCSConfig {
 
     public static Dictionary<string, string[]> SOFA_2_MATERIAL_REGISTRY = new Dictionary<string, string[]>() {
         { "AI2-THOR/Materials/Fabrics/Sofa2_Grey", new string[] { "grey" } },
-        { "AI2-THOR/Materials/Fabrics/Sofa2_White", new string[] { "white" } }
+        { "AI2-THOR/Materials/Fabrics/Sofa2_White", new string[] { "white" } },
+        // Default material
+        { "AI2-THOR/Materials/Fabrics/Sofa2_Fabric_AlbedoTransparency", new string[] { "grey" } }
     };
 
     public static Dictionary<string, string[]> SOFA_3_MATERIAL_REGISTRY = new Dictionary<string, string[]>() {

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -486,12 +486,12 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         }
 
         this.bodyRotationActionData = //left right
-            new MCSRotationData(transform.rotation, Quaternion.Euler(new Vector3(0.0f, response.rotation.y, 0.0f)), false);
+            new MCSRotationData(transform.rotation, Quaternion.Euler(new Vector3(0.0f, response.rotation.y, 0.0f)));
         this.lookRotationActionData = !reset ? //if not reseting then free look up down
-            new MCSRotationData(m_Camera.transform.rotation, Quaternion.Euler(new Vector3(response.horizon, 0.0f, 0.0f)), false) :
-            new MCSRotationData(m_Camera.transform.rotation, Quaternion.Euler(Vector3.zero), true);
+            new MCSRotationData(m_Camera.transform.rotation, Quaternion.Euler(new Vector3(response.horizon, 0.0f, 0.0f))) :
+            new MCSRotationData(m_Camera.transform.rotation, Quaternion.Euler(Vector3.zero));
 
-        this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
+        this.lastActionStatus = Enum.GetName(typeof(ActionStatus), reset ? ActionStatus.CANNOT_ROTATE : ActionStatus.SUCCESSFUL);
     }
 
     public void SimulatePhysics() {
@@ -529,12 +529,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             }
         } //for rotation
         else if (this.inputWasRotateLook) {
-            if (this.lookRotationActionData.reset) {
-                ResetLookRotation(this.lookRotationActionData);
-            } else {
-                RotateLookAcrossFrames(this.lookRotationActionData);
-            }
-
+            RotateLookAcrossFrames(this.lookRotationActionData);
             RotateLookBodyAcrossFrames(this.bodyRotationActionData);
             this.actionFrameCount++;
             if (this.actionFrameCount == this.substeps) {
@@ -897,19 +892,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         Vector3 updatedRotation = new Vector3(0, rotationChange / this.substeps, 0);
         transform.rotation = Quaternion.Euler(transform.rotation.eulerAngles + updatedRotation);
     }
-
-    public void ResetLookRotation(MCSRotationData rotationActionData)
-    {
-        Quaternion currentAngle = rotationActionData.startingRotation;
-        Quaternion endAngle = rotationActionData.endRotation;
-
-        float horizonChange = currentAngle.eulerAngles.x - endAngle.eulerAngles.x;
-        horizonChange = horizonChange > maxHorizon ? horizonChange - 360 : horizonChange;
-        Vector3 lookChange = new Vector3(horizonChange, 0, 0);
-
-        Vector3 changePerFrame = -lookChange / 5f; //up or down per frame
-        m_Camera.transform.rotation = Quaternion.Euler(m_Camera.transform.rotation.eulerAngles + changePerFrame);
-    }
 }
 
 /* class for contatining movement data */
@@ -931,11 +913,9 @@ public class MCSMovementActionData {
 public class MCSRotationData {
     public Quaternion startingRotation;
     public Quaternion endRotation;
-    public bool reset;
 
-    public MCSRotationData(Quaternion startingRotation, Quaternion endRotation, bool reset) {
+    public MCSRotationData(Quaternion startingRotation, Quaternion endRotation) {
         this.startingRotation = startingRotation;
         this.endRotation = endRotation;
-        this.reset = reset;
     }
 }

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -690,18 +690,21 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         sizeY = sizeY * boundingBoxCollider.size.y;
         sizeZ = sizeZ * boundingBoxCollider.size.z;
 
-        float multiplierY = (target.BoundingBox.transform.parent.localScale.y / this.AgentHand.transform.parent.localScale.y);
-        float multiplierZ = (target.BoundingBox.transform.parent.localScale.z / this.AgentHand.transform.parent.localScale.z);
+        float multiplierY = (target.BoundingBox.transform.parent.localScale.y / this.transform.localScale.y);
+        float multiplierZ = (target.BoundingBox.transform.parent.localScale.z / this.transform.localScale.z);
         positionY = positionY * multiplierY;
         positionZ = positionZ * multiplierZ;
         sizeY = sizeY * multiplierY;
         sizeZ = sizeZ * multiplierZ;
 
-        this.AgentHand.transform.localPosition = new Vector3(
-            this.AgentHand.transform.localPosition.x,
-            -1 * ((sizeY / 2.0f) + positionY + MCSController.DISTANCE_HELD_OBJECT_Y),
-            ((sizeZ / 2.0f) - positionZ + MCSController.DISTANCE_HELD_OBJECT_Z)
-        );
+        float handY = -1 * ((sizeY / 2.0f) + positionY + MCSController.DISTANCE_HELD_OBJECT_Y);
+        float handZ = ((sizeZ / 2.0f) - positionZ + MCSController.DISTANCE_HELD_OBJECT_Z);
+
+        // Ensure that a tall held object is not positioned inside of the floor below.
+        float minY = (sizeY / 2.0f) - positionY - (this.transform.position.y / this.transform.localScale.y) +
+            MCSController.DISTANCE_HELD_OBJECT_Y;
+
+        this.AgentHand.transform.localPosition = new Vector3(this.AgentHand.transform.localPosition.x, Math.Max(handY, minY), handZ);
     }
 
     public void Crawl(ServerAction action) {

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -672,16 +672,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     }
 
     private ObjectMetadata UpdatePositionDistanceAndDirectionInObjectMetadata(GameObject gameObject, ObjectMetadata objectMetadata) {
-        // Use the object's renderer (each object should have a renderer, except maybe shelf children in complex
-        // receptacle objects) for its position because its transform's position may not be its actual position
-        // in the camera since the renderer may be defined in a child object with an offset position.
-        Renderer renderer = gameObject.GetComponentInChildren<Renderer>();
-        if (renderer != null) {
-            objectMetadata.position = renderer.bounds.center;
-            // Use the object's new position for the distance previously set in generateObjectMetadata.
-            objectMetadata.distance = Vector3.Distance(this.transform.position, objectMetadata.position);
-        }
-
         // From https://docs.unity3d.com/Manual/DirectionDistanceFromOneObjectToAnother.html
         objectMetadata.heading = objectMetadata.position - this.transform.position;
         objectMetadata.direction = (objectMetadata.heading / objectMetadata.heading.magnitude);

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -466,6 +466,16 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         base.ResetAgentHandPosition(action);
     }
 
+    public override void ResetAgentHandRotation(ServerAction action) {
+        // Don't reset the player's hand rotation if the player is just moving or rotating.
+        // Use this.lastAction here because this function's ServerAction argument is sometimes null.
+        if (this.lastAction.StartsWith("Move") || this.lastAction.StartsWith("Rotate") ||
+            this.lastAction.StartsWith("Look") || this.lastAction.StartsWith("Teleport")) {
+            return;
+        }
+        base.ResetAgentHandRotation(action);
+    }
+
     public override void RotateLook(ServerAction response)
     {
         // Need to calculate current rotation/horizon and increment by inputs given

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4159,7 +4159,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 handSOP.transform.parent = previousParent;
 
                 errorMessage = "No valid positions to place object found";
-                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
                 actionFinished(false);
                 return;
             }
@@ -4251,7 +4251,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             target.transform.position = AgentHand.transform.position;
             // target.transform.rotation = AgentHand.transform.rotation; - keep this line if we ever want to change the pickup position to be constant relative to the Agent Hand and Agent Camera rather than aligned by world axis
-            target.transform.rotation = transform.rotation;
+            // MCS remove next line
+            // target.transform.rotation = transform.rotation;
             target.transform.SetParent(AgentHand.transform);
             ItemInHand = target.gameObject;
             ItemInHand.layer = 9; // SimObjInvisible

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2969,7 +2969,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             // }
         }
 
-        public void ResetAgentHandRotation(ServerAction action = null) {
+        public virtual void ResetAgentHandRotation(ServerAction action = null) {
             AgentHand.transform.localRotation = Quaternion.Euler(Vector3.zero);
             // SimObjPhysics sop = AgentHand.GetComponentInChildren<SimObjPhysics>();
             // if (sop != null) {
@@ -4070,6 +4070,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     ItemInHand.GetComponent<Rigidbody>().isKinematic = true;
                     ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;//remove in agent hand flag
                     ItemInHand.layer = 8; // SimObjVisible
+                    // MCS ADDED BLOCK
+                    ItemInHand.GetComponent<SimObjPhysics>().MyColliders.ToList().ForEach((collider) => {
+                        collider.gameObject.layer = 8; // SimObjVisible
+                    });
                     ItemInHand = null;
                     DefaultAgentHand();
                     this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);
@@ -4159,6 +4163,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             if (script.PlaceObjectReceptacle(spawnPoints, ItemInHand.GetComponent<SimObjPhysics>(), action.placeStationary, -1, 90, placeUpright, null)) {
                 ItemInHand.layer = 8; // SimObjVisible
+                // MCS ADDED BLOCK
+                ItemInHand.GetComponent<SimObjPhysics>().MyColliders.ToList().ForEach((collider) => {
+                    collider.gameObject.layer = 8; // SimObjVisible
+                });
                 ItemInHand = null;
                 DefaultAgentHand();
 
@@ -4266,12 +4274,17 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 PickupContainedObjects(target);
 
             target.transform.position = AgentHand.transform.position;
-            // target.transform.rotation = AgentHand.transform.rotation; - keep this line if we ever want to change the pickup position to be constant relative to the Agent Hand and Agent Camera rather than aligned by world axis
-            // MCS remove next line
-            // target.transform.rotation = transform.rotation;
+            // MCS ADDED NEXT LINE
+            Quaternion previousRotation = target.transform.localRotation;
             target.transform.SetParent(AgentHand.transform);
+            // MCS ADDED NEXT LINE
+            target.transform.localRotation = previousRotation;
             ItemInHand = target.gameObject;
             ItemInHand.layer = 9; // SimObjInvisible
+            // MCS ADDED BLOCK
+            ItemInHand.GetComponent<SimObjPhysics>().MyColliders.ToList().ForEach((collider) => {
+                collider.gameObject.layer = 9; // SimObjInvisible
+            });
 
             /* TODO MCS
             if (!action.forceAction && isHandObjectColliding(true)) {
@@ -4470,7 +4483,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 if (!action.forceAction && isHandObjectColliding(false)) {
                     errorMessage = ItemInHand.transform.name + " can't be dropped. It must be clear of all other collision first, including the Agent";
                     Debug.Log(errorMessage);
-                    this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.FAILED);
+                    this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
                     actionFinished(false);
                     return false;
                 } else {
@@ -4519,6 +4532,10 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
                     ItemInHand.GetComponent<SimObjPhysics>().isInAgentHand = false;
                     ItemInHand.layer = 8; // SimObjVisible
+                    // MCS ADDED BLOCK
+                    ItemInHand.GetComponent<SimObjPhysics>().MyColliders.ToList().ForEach((collider) => {
+                        collider.gameObject.layer = 8; // SimObjVisible
+                    });
                     ItemInHand = null;
                     return true;
                 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -3989,22 +3989,19 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
             }
 
-            //get the target receptacle based on the action receptacle object ID
-            SimObjPhysics targetReceptacle = null;
-
-            foreach (SimObjPhysics sop in VisibleSimObjs(true)) { //action.forceVisible is usually false
-            bool inSceneIsStackingOrInVisibleSimObjsIsNotStacking = (((!string.IsNullOrEmpty(action.receptacleObjectId)) && action.receptacleObjectId == sop.UniqueID) && 
-                (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Stacking) || VisibleSimObjs(action.forceVisible).Contains(sop)));
-                if (inSceneIsStackingOrInVisibleSimObjsIsNotStacking) {
-                    targetReceptacle = sop; 
-                    break;
-                }
+            if (!physicsSceneManager.UniqueIdToSimObjPhysics.ContainsKey(action.receptacleObjectId)) {
+                errorMessage = "Object ID " + action.receptacleObjectId + " appears to be invalid.";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OBJECT);
+                actionFinished(false);
+                return;
             }
 
-            if (targetReceptacle == null) {
-                errorMessage = "No valid Receptacle found";
-                Debug.Log(errorMessage);
-                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
+            SimObjPhysics targetReceptacle = physicsSceneManager.UniqueIdToSimObjPhysics[action.receptacleObjectId];
+
+            if (targetReceptacle == null || !targetReceptacle.GetComponent<SimObjPhysics>()) {
+                errorMessage = action.receptacleObjectId + " is not interactable.";
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
                 actionFinished(false);
                 return;
             }
@@ -4027,6 +4024,25 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     actionFinished(false);
                     return;
                 }
+            }
+
+            targetReceptacle = null;
+
+            foreach (SimObjPhysics sop in VisibleSimObjs(true)) { //action.forceVisible is usually false
+            bool inSceneIsStackingOrInVisibleSimObjsIsNotStacking = (((!string.IsNullOrEmpty(action.receptacleObjectId)) && action.receptacleObjectId == sop.UniqueID) &&
+                (sop.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Stacking) || VisibleSimObjs(action.forceVisible).Contains(sop)));
+                if (inSceneIsStackingOrInVisibleSimObjsIsNotStacking) {
+                    targetReceptacle = sop;
+                    break;
+                }
+            }
+
+            if (targetReceptacle == null) {
+                errorMessage = "No valid Receptacle found";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
+                actionFinished(false);
+                return;
             }
 
             //if this receptacle only receives specific objects, check that the ItemInHand is compatible and
@@ -4723,7 +4739,32 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            SimObjPhysics target = null;
+            if (!physicsSceneManager.UniqueIdToSimObjPhysics.ContainsKey(action.objectId)) {
+                errorMessage = "Object ID " + action.objectId + " appears to be invalid.";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OBJECT);
+                actionFinished(false);
+                return;
+            }
+
+            SimObjPhysics target = physicsSceneManager.UniqueIdToSimObjPhysics[action.objectId];
+
+            if (target == null || !target.GetComponent<SimObjPhysics>()) {
+                errorMessage = action.objectId + " is not interactable.";
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
+                actionFinished(false);
+                return;
+            }
+
+            if (!target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle)) {
+                errorMessage = "This target object is NOT a receptacle!";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_RECEPTACLE);
+                actionFinished(false);
+                return;
+            }
+
+            target = null;
 
             if (action.forceAction) {
                 action.forceVisible = true;
@@ -5371,7 +5412,32 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            SimObjPhysics target = null;
+            if (!physicsSceneManager.UniqueIdToSimObjPhysics.ContainsKey(action.objectId)) {
+                errorMessage = "Object ID " + action.objectId + " appears to be invalid.";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OBJECT);
+                actionFinished(false);
+                return;
+            }
+
+            SimObjPhysics target = physicsSceneManager.UniqueIdToSimObjPhysics[action.objectId];
+
+            if (target == null || !target.GetComponent<SimObjPhysics>()) {
+                errorMessage = action.objectId + " is not interactable.";
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
+                actionFinished(false);
+                return;
+            }
+
+            if (!target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle)) {
+                errorMessage = "This target object is NOT a receptacle!";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_RECEPTACLE);
+                actionFinished(false);
+                return;
+            }
+
+            target = null;
 
             if (action.forceAction) {
                 action.forceVisible = true;

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -2269,6 +2269,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
+            // Must call this now because it will set target.isInteractable
+            bool isNotVisible = !objectIsCurrentlyVisible(target, maxVisibleDistance);
+
             if (!action.forceAction && target.isInteractable == false) {
                 errorMessage = "Target is not interactable and is probably occluded by something!";
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_PICKUPABLE);
@@ -2276,7 +2279,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) {
+            if (isNotVisible) {
                 Vector3 targetMoveYHeightToAgentHeight = target.transform.position;
                 targetMoveYHeightToAgentHeight.y = transform.position.y;
                 if (Vector3.Distance(targetMoveYHeightToAgentHeight, transform.position) < maxVisibleDistance) {
@@ -2289,7 +2292,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 }
             }
 
-            if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) {
+            if (isNotVisible) {
                 errorMessage = "Target " + action.objectId + " is not visible";
                 Debug.Log(errorMessage);
                 Debug.Log(string.Format("Agent - X position: {0} - Z position {1}.", player.transform.position.x, player.transform.position.z));
@@ -2686,9 +2689,11 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                             return true;
                         }
 
-                        if ((res.rigidbody.mass > this.GetComponent<Rigidbody>().mass && res.transform.tag == "SimObjPhysics" && res.transform.GetComponent<StructureObject>() == null) ||
-                            (res.transform.GetComponent<StructureObject>() != null))
-                        {
+                        SimObjPhysics simObjPhysics = res.transform.GetComponent<SimObjPhysics>();
+                        StructureObject structureObject = res.transform.GetComponent<StructureObject>();
+                        bool immobile = simObjPhysics == null || (simObjPhysics.PrimaryProperty != SimObjPrimaryProperty.CanPickup &&
+                            simObjPhysics.PrimaryProperty != SimObjPrimaryProperty.Moveable);
+                        if (structureObject != null || immobile || res.rigidbody.mass > this.GetComponent<Rigidbody>().mass) {
                             int thisAgentNum = agentManager.agents.IndexOf(this);
                             errorMessage = res.transform.name + " is blocking Agent " + thisAgentNum.ToString() + " from moving " + orientation;
                             //the moment we find a result that is blocking, return false here
@@ -4192,6 +4197,9 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
+            // Must call this now because it will set target.isInteractable
+            bool isNotVisible = !objectIsCurrentlyVisible(target, maxVisibleDistance);
+
             if (!action.forceAction && target.isInteractable == false) {
                 errorMessage = action.objectId + " is not interactable and perhaps it is occluded by something.";
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
@@ -4199,7 +4207,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            if (!objectIsCurrentlyVisible(target, maxVisibleDistance)) { 
+            if (isNotVisible) {
                 Vector3 targetMoveYHeightToAgentHeight = target.transform.position;
                 targetMoveYHeightToAgentHeight.y = transform.position.y;
                 if (Vector3.Distance(targetMoveYHeightToAgentHeight, transform.position) < maxVisibleDistance) {
@@ -4212,7 +4220,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 
             }
 
-            if (!action.forceAction && !objectIsCurrentlyVisible(target, maxVisibleDistance)) {
+            if (!action.forceAction && isNotVisible) {
                 errorMessage = action.objectId + " is not visible.";
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
                 actionFinished(false);

--- a/unity/Assets/Scripts/SimObjPhysics.cs
+++ b/unity/Assets/Scripts/SimObjPhysics.cs
@@ -483,10 +483,17 @@ public class SimObjPhysics : MonoBehaviour, SimpleSimObj
 		sortedReceptacleTriggerBoxes.Sort((GameObject one, GameObject two) =>
 			one.transform.position.y.CompareTo(two.transform.position.y));
 
+		List<SimObjSecondaryProperty> secondaryProperties = new List<SimObjSecondaryProperty>(this.SecondaryProperties);
+
 		foreach(GameObject rtb in sortedReceptacleTriggerBoxes)
 		{
-			Contains containsScript = rtb.GetComponent<Contains>();
-			temp.AddRange(containsScript.GetValidSpawnPoints(ReturnPointsCloseToAgent));
+            double centerY = System.Math.Round(transform.parent.TransformPoint(rtb.transform.position).y, 2);
+            double parentCenterY = System.Math.Round(transform.parent.TransformPoint(BoundingBox.transform.position).y, 2);
+            // MCS Only use a stacking receptacle trigger box that is positioned higher than its parent.
+            if (!secondaryProperties.Contains(SimObjSecondaryProperty.Stacking) || centerY > parentCenterY) {
+                Contains containsScript = rtb.GetComponent<Contains>();
+                temp.AddRange(containsScript.GetValidSpawnPoints(ReturnPointsCloseToAgent));
+            }
 		}
 
 		if(ReturnPointsCloseToAgent)

--- a/unity/ProjectSettings/ProjectSettings.asset
+++ b/unity/ProjectSettings/ProjectSettings.asset
@@ -42,8 +42,8 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 400
-  defaultScreenHeight: 300
+  defaultScreenWidth: 600
+  defaultScreenHeight: 400
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
@@ -53,7 +53,7 @@ PlayerSettings:
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
-  displayResolutionDialog: 0
+  displayResolutionDialog: 2
   iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
   allowedAutorotateToPortraitUpsideDown: 1
@@ -92,7 +92,7 @@ PlayerSettings:
   visibleInBackground: 0
   allowFullscreenSwitch: 1
   graphicsJobMode: 0
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0


### PR DESCRIPTION
- Picked-up objects now retain their previous rotation
- Fixed bugs with stacking objects using the PutObject action
- Trying to look up or down too far (past +/- 90 degrees) now does nothing correctly and returns a new CANNOT_ROTATE action status
- Use an object's closest point rather than its center point to decide on whether to return an OBSTRUCTED action status
- Added the NOT_MOVEABLE action status
- Updated the order in which specific action status are returned (NOT_* vs OUT_OF_REACH)
- Set held object colliders to be invisible so held objects won't obstruct visibility to other objects.
- Updated Changelog in README.