### PR TITLE
Removed movement restriction in MCS Controller.

### DIFF
--- a/unity/Assets/Scripts/DebugDiscreteAgentController.cs
+++ b/unity/Assets/Scripts/DebugDiscreteAgentController.cs
@@ -8,6 +8,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
 {
     public class DebugDiscreteAgentController : MonoBehaviour
     {   
+        public static float MOVE_MAX = 0.1f;
+
         public GameObject InputFieldObj = null;
         public PhysicsRemoteFPSAgentController PhysicsController = null;
         private InputField inputField;
@@ -143,7 +145,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             else
                             {
                                 action.action = "MoveAhead";
-                                action.moveMagnitude = WalkMagnitude;		
+                                action.moveMagnitude = Mathf.Min(WalkMagnitude, DebugDiscreteAgentController.MOVE_MAX);
                                 PhysicsController.ProcessControlCommand(action);
                             }
                         }
@@ -160,7 +162,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             else
                             {
                                 action.action = "MoveBack";
-                                action.moveMagnitude = WalkMagnitude;	
+                                action.moveMagnitude = Mathf.Min(WalkMagnitude, DebugDiscreteAgentController.MOVE_MAX);
                                 PhysicsController.ProcessControlCommand(action);
                             }
                         }
@@ -177,7 +179,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             else
                             {
                                 action.action = "MoveLeft";
-                                action.moveMagnitude = WalkMagnitude;	
+                                action.moveMagnitude = Mathf.Min(WalkMagnitude, DebugDiscreteAgentController.MOVE_MAX);
                                 PhysicsController.ProcessControlCommand(action);
                             }
                         }
@@ -194,7 +196,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             else
                             {
                                 action.action = "MoveRight";
-                                action.moveMagnitude = WalkMagnitude;	
+                                action.moveMagnitude = Mathf.Min(WalkMagnitude, DebugDiscreteAgentController.MOVE_MAX);
                                 PhysicsController.ProcessControlCommand(action);
                             }
                         }

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -9,7 +9,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     public static float STANDING_POSITION_Y = 0.4625f;
     public static float CRAWLING_POSITION_Y = STANDING_POSITION_Y/2;
     public static float LYING_POSITION_Y = 0.1f;
-    public static float MOVE_MAX = 0.1f;
 
     public static float DISTANCE_HELD_OBJECT_Y = 0.1f;
     public static float DISTANCE_HELD_OBJECT_Z = 0.3f;
@@ -788,7 +787,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     //overrides from PhysicsRemoteFPSAgentController which enable agent/object collisions
     public override void MoveLeft(ServerAction action) {
         action.moveMagnitude = action.moveMagnitude > 0 ? action.moveMagnitude : gridSize;
-        action.moveMagnitude = Mathf.Min(action.moveMagnitude, MCSController.MOVE_MAX);
         this.movementActionData = new MCSMovementActionData(-1 * transform.right * action.moveMagnitude,
             action.objectId,
             action.maxAgentsDistance, action.forceAction);
@@ -798,7 +796,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
 
     public override void MoveRight(ServerAction action) {
         action.moveMagnitude = action.moveMagnitude > 0 ? action.moveMagnitude : gridSize;
-        action.moveMagnitude = Mathf.Min(action.moveMagnitude, MCSController.MOVE_MAX);
         this.movementActionData = new MCSMovementActionData(transform.right * action.moveMagnitude,
             action.objectId,
             action.maxAgentsDistance, action.forceAction);
@@ -808,7 +805,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
 
     public override void MoveAhead(ServerAction action) {
         action.moveMagnitude = action.moveMagnitude > 0 ? action.moveMagnitude : gridSize;
-        action.moveMagnitude = Mathf.Min(action.moveMagnitude, MCSController.MOVE_MAX);
         this.movementActionData = new MCSMovementActionData(transform.forward * action.moveMagnitude,
             action.objectId,
             action.maxAgentsDistance, action.forceAction);
@@ -818,7 +814,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
 
     public override void MoveBack(ServerAction action) {
         action.moveMagnitude = action.moveMagnitude > 0 ? action.moveMagnitude : gridSize;
-        action.moveMagnitude = Mathf.Min(action.moveMagnitude, MCSController.MOVE_MAX);
         this.movementActionData = new MCSMovementActionData(-1 * transform.forward * action.moveMagnitude,
             action.objectId,
             action.maxAgentsDistance, action.forceAction);


### PR DESCRIPTION
The movement restriction on the UNITY side was originally added to fix a bug with moving around while running scenes with the Unity Editor: https://github.com/NextCenturyCorporation/ai2thor/commit/2988a60400a5c9580b5fe301cede237fb054c721

I've simply shifted the restriction from the MCSController to the DebugDiscreteAgentController so it only affects runs with the Unity Editor. Our MCS Python library already adds its own movement restrictions, and those will remain in place until we remove them.

Since this is a minor change, I wasn't sure if we should "get it in" before the big AI2-THOR merge.