### PR TITLE
Mcs 473 pickup contained objects

### DIFF
--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4629,7 +4629,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         //make sure not to pick up any sliced objects because those should remain uninteractable i they have been sliced
         public void PickupContainedObjects(SimObjPhysics target) 
         {
-            if (target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle) && !target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Stacking))
+            //Removed !target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Stacking check because it causes items in bowl not being picked up.
+            if (target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.Receptacle))
             {
                 foreach (SimObjPhysics sop in target.SimObjectsContainedByReceptacle) 
                 {


### PR DESCRIPTION
Fixed issue where some containers, when picked up, did not have their contained objects picked up.  This fixes this.

There is a corresponding pull request for integration tests. https://github.com/NextCenturyCorporation/MCS/pull/304

Note: Integration test 46 and 48 will fail until pull request in MCS 303 is merged.  https://github.com/NextCenturyCorporation/MCS/pull/303