### PR TITLE
MCS-619 Leaking materials - added code to remove unused assets

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -220,6 +220,9 @@ public class MCSMain : MonoBehaviour {
                 GameObject gameOrParentObject = objectConfig.GetParentObject() ?? objectConfig.GetGameObject();
                 Destroy(gameOrParentObject);
             });
+            //The way we use materials creates a bunch of instances.  This should clear them out after 
+            //we clean up the objects.
+            Resources.UnloadUnusedAssets();
         }
 
         if (scene != null) {


### PR DESCRIPTION
This is a much simplier fix to MCS-619 leaking materials.  After cleaning up all the objects when switching scenes, we delete all unused assets via a unity command.