### PR TITLE
Hotfix to issue with showing overlapping fuse walls from agent instrumental action scenes in object instance segmentation masks.

### DIFF
--- a/unity/Assets/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/ImageSynthesis/ImageSynthesis.cs
@@ -329,6 +329,9 @@ public class ImageSynthesis : MonoBehaviour {
 				classTag = "" + sop.Type;
 				objTag = sop.ObjectID;
 			}
+            if (objTag.StartsWith("fuse_wall_")) {
+                objTag = "fuse_wall";
+            }
 
 
 			Color classColor = ColorEncoding.EncodeTagAsColor (classTag);


### PR DESCRIPTION
Possible fix to issue https://github.com/NextCenturyCorporation/MCS/issues/336

The issue is that the fuse walls are composed of many segments that are overlapping with each other.

Current:
![fuse-wall-current](https://user-images.githubusercontent.com/10994382/118283551-7d4d1180-b49d-11eb-820e-8c57df740080.png)

Fixed:
![fuse-wall-fixed](https://user-images.githubusercontent.com/10994382/118283555-7d4d1180-b49d-11eb-8b60-a48a977b32e3.png)

Options include:
- Adding a special case in our Unity code for the fuse walls (i.e. exactly what I've done in this PR). Very hacky, but trivial to implement.
- Update the scene generator to reduce the size of fuse wall segments so they don't overlap. Would require recreating and re-releasing all the instrumental action scenes.
- Dynamically identifying overlapping fuse wall segments and reducing their size in Unity? Would likely either be very complicated or hacky.

I'm open to discussing our options!

EDIT: Adding the RGB image for context:

![fuse-wall-frame](https://user-images.githubusercontent.com/10994382/118284840-dcf7ec80-b49e-11eb-84a4-8567a260191f.png)
