### PR TITLE
Fixed Ramps

### DIFF
--- a/unity/Assets/Resources/MCS/Scenes/RAMPS.json
+++ b/unity/Assets/Resources/MCS/Scenes/RAMPS.json
@@ -5,19 +5,19 @@
   "wallMaterial": "AI2-THOR/Materials/Metals/Brass 1",
   "performerStart": {
     "position": {
-      "x": 4.88,
+      "x": 4.5,
       "y": 0,
-      "z": -3.74
+      "z": 0.5
     },
     "rotation": {
       "x": 0,
-      "y": 270,
+      "y": 180,
       "z": 0
     }
   },
   "objects": [
     {
-      "id": "wall_77a657d8-e11f-4761-b13f-ae67a50e2c69",
+      "id": "wall_1",
       "materials": ["AI2-THOR/Materials/Metals/Brass 1"],
       "type": "cube",
       "kinematic": "true",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "id": "wall_77a657d8-e11f-4761-b13f-ae67a50e2c69",
+      "id": "wall_2",
       "materials": ["AI2-THOR/Materials/Metals/Brass 1"],
       "type": "cube",
       "kinematic": "true",
@@ -73,7 +73,7 @@
       ]
     },
     {
-      "id": "wall_77a657d8-e11f-4761-b13f-ae67a50e2c69",
+      "id": "wall_3",
       "materials": ["AI2-THOR/Materials/Metals/Brass 1"],
       "type": "cube",
       "kinematic": "true",
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "id": "wall_77a657d8-e11f-4761-b13f-ae67a50e2c69",
+      "id": "wall_4",
       "materials": ["AI2-THOR/Materials/Metals/Brass 1"],
       "type": "cube",
       "kinematic": "true",
@@ -129,7 +129,7 @@
       ]
     },
     {
-      "id": "wall_77a657d8-e11f-4761-b13f-ae67a50e2c69",
+      "id": "wall_5",
       "materials": ["AI2-THOR/Materials/Metals/Brass 1"],
       "type": "cube",
       "kinematic": "true",
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "id": "wall_77a657d8-e11f-4761-b13f-ae67a50e2c69",
+      "id": "wall_6",
       "materials": ["AI2-THOR/Materials/Metals/Brass 1"],
       "type": "cube",
       "kinematic": "true",
@@ -185,7 +185,7 @@
       ]
     },
     {
-      "id": "wall_77a657d8-e11f-4761-b13f-ae67a50e2c69",
+      "id": "wall_7",
       "materials": ["AI2-THOR/Materials/Metals/Brass 1"],
       "type": "cube",
       "kinematic": "true",

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2109,6 +2109,7 @@ MonoBehaviour:
   DroneBasket: {fileID: 1769782113}
   inHighFrictionArea: 0
   agentState: 3
+  showDebugCapsuleGizmos: 0
   agentManager: {fileID: 0}
   m_Camera: {fileID: 0}
   cameraOrthSize: 0

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2136,6 +2136,12 @@ MonoBehaviour:
   substeps: 5
   step: 0
   fpsAgent: {fileID: 1752557969}
+--- !u!4 &506323130 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400000, guid: 5e9e851c0e142814dac026a256ba2ac0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1752557968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &513116322 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1762015268591634, guid: 5e9e851c0e142814dac026a256ba2ac0,
@@ -2467,6 +2473,51 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1752557968}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1125765176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1125765177}
+  - component: {fileID: 1125765178}
+  m_Layer: 10
+  m_Name: CapsuleColliderForGroundCollisions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1125765177
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1125765176}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children: []
+  m_Father: {fileID: 506323130}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1125765178
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1125765176}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.675
+  m_Height: 2.8
+  m_Direction: 1
+  m_Center: {x: 0, y: -1, z: 0}
 --- !u!1 &1180321326
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -4263,7 +4263,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 940f8586c495e37cc80926a37e932c65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSceneFile: RAMPS
+  defaultSceneFile: 
   enableVerboseLog: 0
   enableDebugLogsInEditor: 1
   ai2thorObjectRegistryFile: ai2thor_object_registry

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -2133,6 +2133,7 @@ MonoBehaviour:
   MyFaceMesh: {fileID: 497714281}
   AdvancePhysicsStepCount: 0
   TargetCircles: []
+  groundObjectsCollider: {fileID: 1125765178}
   substeps: 5
   step: 0
   fpsAgent: {fileID: 1752557969}
@@ -2484,7 +2485,7 @@ GameObject:
   - component: {fileID: 1125765177}
   - component: {fileID: 1125765178}
   m_Layer: 10
-  m_Name: CapsuleColliderForGroundCollisions
+  m_Name: CapsuleColliderForObjectGroundCollisions
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2514,7 +2515,7 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
-  m_Radius: 0.675
+  m_Radius: 0.5
   m_Height: 2.8
   m_Direction: 1
   m_Center: {x: 0, y: -1, z: 0}
@@ -3821,7 +3822,7 @@ PrefabInstance:
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: m_Radius
-      value: 0.25
+      value: 0.251
       objectReference: {fileID: 0}
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}

--- a/unity/Assets/Scenes/MCS.unity
+++ b/unity/Assets/Scenes/MCS.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.7170012, g: 0.7306422, b: 0.7505908, a: 1}
+  m_IndirectSpecularColor: {r: 0.7040911, g: 0.71842074, b: 0.7375759, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3765,7 +3765,7 @@ PrefabInstance:
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: m_Height
-      value: 1.3875
+      value: 1.23
       objectReference: {fileID: 0}
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
@@ -3775,7 +3775,7 @@ PrefabInstance:
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
       propertyPath: m_Center.y
-      value: -0.4625
+      value: -0.33
       objectReference: {fileID: 0}
     - target: {fileID: 136752831871764314, guid: 5e9e851c0e142814dac026a256ba2ac0,
         type: 3}
@@ -4263,7 +4263,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 940f8586c495e37cc80926a37e932c65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSceneFile: 
+  defaultSceneFile: RAMPS
   enableVerboseLog: 0
   enableDebugLogsInEditor: 1
   ai2thorObjectRegistryFile: ai2thor_object_registry
@@ -4272,6 +4272,7 @@ MonoBehaviour:
   defaultCeilingMaterial: AI2-THOR/Materials/Walls/Drywall
   defaultFloorMaterial: AI2-THOR/Materials/Fabrics/CarpetWhite 3
   defaultWallsMaterial: AI2-THOR/Materials/Walls/DrywallBeige
+  isPassiveScene: 0
 --- !u!4 &1891392285
 Transform:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -83,7 +83,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
 
         //These are for ramp debugging gizmos and helpful for capusle collider visualizations when checking if movement is possible - see OnDrawGizmosSelected()
         [Tooltip("This will show the top and bottom of the agent's collider used for any capsule casting methods. A ray is displayed a 45 degree angle from the base of capsule cast for ramp ascension. " +
-        "Another vertical ray is displayed at the base of the agent showing where the agent's height is based on the strucute below.")]
+        "Another vertical ray is displayed at the base of the agent showing where the agent's height is based on the structure below.")]
         public bool showDebugCapsuleGizmos = false;
         private Vector3 point1Gizmo;
         private Vector3 point2Gizmo;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -82,11 +82,15 @@ namespace UnityStandardAssets.Characters.FirstPerson
         protected string inputDirection;
 
         //These are for ramp debugging gizmos and helpful for capusle collider visualizations when checking if movement is possible - see OnDrawGizmosSelected()
-        //private Vector3 point1Gizmo;
-        //private Vector3 point2Gizmo;
-        //private float radiusGizmo;
-        //private Vector3 directionGizmo;
-        //private Ray rayGizmo;
+        [Tooltip("This will show the top and bottom of the agent's collider used for any capsule casting methods. A ray is displayed a 45 degree angle from the base of capsule cast for ramp ascension. " +
+        "Another vertical ray is displayed at the base of the agent showing where the agent's height is based on the strucute below.")]
+        public bool showDebugCapsuleGizmos = false;
+        private Vector3 point1Gizmo;
+        private Vector3 point2Gizmo;
+        private float radiusGizmo;
+        private Vector3 directionGizmo;
+        private Ray rayGizmo1;
+        private Ray rayGizmo2;
 
         public bool IsVisible
         {
@@ -879,18 +883,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 default:
                     Debug.Log("Incorrect orientation input! Allowed orientations (0 - forward, 90 - right, 180 - backward, 270 - left) ");
                     break;
-            }
-
-            /*
-            RaycastHit[] sweepResults = capsuleCastAllForAgent(
-                GetComponent<CapsuleCollider>(),
-                m_CharacterController.skinWidth,
-                transform.position,
-                dir,
-                moveMagnitude,
-                1 << 8 | 1 << 10
-            );*/
-
+            }        
             Vector3 p1,p2;
             float radius;
             CapsuleCastInfoByShootingRayToFloor(out p1, out p2, out radius);
@@ -982,12 +975,13 @@ namespace UnityStandardAssets.Characters.FirstPerson
             float radius;
             Vector3 p1, p2;
             CapsuleCastInfoByShootingRayToFloor(out p1, out p2, out radius);
+
             //Gizmos debbuging
-            //this.point1Gizmo = p1;
-            //this.point2Gizmo = p2;
-            //this.radiusGizmo = radius;
-            //this.directionGizmo = direction;
-            //Debug.DrawRay(p1, direction, Color.white, 10f, false);
+            this.point1Gizmo = p1;
+            this.point2Gizmo = p2;
+            this.radiusGizmo = radius;
+            this.directionGizmo = direction;
+            this.rayGizmo1 = new Ray(p1, direction);
 
             RaycastHit[] hits = Physics.CapsuleCastAll(p1, p2, radius, direction, length + rayCastBuffer, layerMask, QueryTriggerInteraction.Ignore);
             foreach (RaycastHit point in hits)
@@ -1010,11 +1004,8 @@ namespace UnityStandardAssets.Characters.FirstPerson
             radius  = cc.radius * Mathf.Max(transform.localScale.x, transform.localScale.z);
             if (Physics.SphereCast(origin, radius, Vector3.down, out baseHit, Mathf.Infinity, layerMask, QueryTriggerInteraction.Ignore))
             {
-                baseHeight = baseHit.point.y;
-                //Gizmos debbuging
-                //rayGizmo = new Ray();
-                //rayGizmo.direction = Vector3.up;
-                //rayGizmo.origin = baseHit.point;
+                baseHeight = baseHit.point.y;           
+                rayGizmo2 = new Ray(baseHit.point, Vector3.up); //Gizmos Debugging
             }
 
             origin = new Vector3(transform.position.x, baseHeight, transform.position.z);
@@ -3346,12 +3337,18 @@ namespace UnityStandardAssets.Characters.FirstPerson
             //Radius is the collider radius for both points, direction is the path of the capsule
             //The bottom point is drawn twice, one at its current location, 
             //the second at a point 45 degrees up in the direction of movement with a seperation of movement magnitude
-            //Gizmos.color = Color.white;
-            //Gizmos.DrawWireSphere(point1Gizmo, radiusGizmo);
-            //Gizmos.DrawWireSphere(point1Gizmo + directionGizmo.normalized * 0.1f, radiusGizmo);
-            //Gizmos.color = Color.red;
-            //Gizmos.DrawWireSphere(point2Gizmo, radiusGizmo);
-            //Gizmos.DrawRay(rayGizmo);
+            if(showDebugCapsuleGizmos)
+            {
+                Gizmos.color = Color.white;
+                Gizmos.DrawWireSphere(point1Gizmo, radiusGizmo);
+                Gizmos.DrawWireSphere(point1Gizmo + directionGizmo.normalized * 0.1f, radiusGizmo);
+                Gizmos.DrawWireSphere(point1Gizmo, radiusGizmo);
+                Gizmos.DrawRay(rayGizmo1);
+                Gizmos.color = Color.red;
+                Gizmos.DrawWireSphere(point2Gizmo, radiusGizmo);
+                Gizmos.DrawRay(rayGizmo2);
+
+            }
         }
         #endif
 

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -881,6 +881,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
                     break;
             }
 
+            /*
             RaycastHit[] sweepResults = capsuleCastAllForAgent(
                 GetComponent<CapsuleCollider>(),
                 m_CharacterController.skinWidth,
@@ -888,9 +889,14 @@ namespace UnityStandardAssets.Characters.FirstPerson
                 dir,
                 moveMagnitude,
                 1 << 8 | 1 << 10
-            );
+            );*/
 
-            bool hasNoBlockingObjectsInWay = AgentCanMoveRayCastSweep(ref moveMagnitude, orientation, sweepResults);
+            Vector3 p1,p2;
+            float radius;
+            CapsuleCastInfoByShootingRayToFloor(out p1, out p2, out radius);
+            RaycastHit[] hits = Physics.CapsuleCastAll(p1, p2, radius, dir, moveMagnitude, 1<<8, QueryTriggerInteraction.Ignore);
+
+            bool hasNoBlockingObjectsInWay = AgentCanMoveRayCastSweep(ref moveMagnitude, orientation, hits);
             return hasNoBlockingObjectsInWay;
         }
 

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -21,6 +21,12 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     public static float LYING_COLLIDER_HEIGHT = 0.05f;
     public static float LYING_COLLIDER_CENTER = 0.15f;
 
+    //This is an extra collider that slightly clips into the ground to ensure collision with objects of any size.
+    //When lying down, the radius increases to simulate the expansion of the body when horizontal
+    public CapsuleCollider groundObjectsCollider;
+    public static float GROUND_OBJECTS_COLLIDER_RADIUS = 0.5f;
+    public static float GROUND_OBJECTS_COLLIDER_LYING_DOWN_RADIUS = 0.675f;
+
 
     public static float DISTANCE_HELD_OBJECT_Y = 0.1f;
     public static float DISTANCE_HELD_OBJECT_Z = 0.3f;
@@ -809,8 +815,9 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         RaycastHit hit;
         LayerMask layerMask = ~(1 << 10);
 
+        float rayCastDistanceBuffer = pose == PlayerPose.LYING ? 0 : 0.2f; //this is needed for being below an angled incline structure
         //if raycast hits an object, the agent does not move on y-axis
-        if (direction == Vector3.up && Physics.SphereCast(origin, AGENT_RADIUS, direction, out hit, Mathf.Abs(startHeight-endHeight) + 0.1f, layerMask) &&
+        if (direction == Vector3.up && Physics.SphereCast(origin, AGENT_RADIUS, direction, out hit, Mathf.Abs(startHeight-endHeight)+rayCastDistanceBuffer, layerMask) &&
             hit.collider.tag == "SimObjPhysics")
         {
             this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OBSTRUCTED);
@@ -824,17 +831,21 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             {
                 cc.height = LYING_COLLIDER_HEIGHT;
                 cc.center = new Vector3(0,LYING_COLLIDER_CENTER,0);
+                groundObjectsCollider.radius = GROUND_OBJECTS_COLLIDER_LYING_DOWN_RADIUS;
             }
             else if(this.pose == PlayerPose.CRAWLING)
             {
                 cc.height = CRAWLING_COLLIDER_HEIGHT;
                 cc.center = new Vector3(0,CRAWLING_COLLIDER_CENTER,0);
+                groundObjectsCollider.radius = GROUND_OBJECTS_COLLIDER_RADIUS;
             }
 
             else
             {
                 cc.height = STANDING_COLLIDER_HEIGHT;
                 cc.center = new Vector3(0,STANDING_COLLIDER_CENTER,0);
+                groundObjectsCollider.radius = GROUND_OBJECTS_COLLIDER_RADIUS;
+
             }
             //SetUpRotationBoxChecks();
             this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.SUCCESSFUL);

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -930,11 +930,11 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         CapsuleCollider myCollider = GetComponent<CapsuleCollider>();
         float radius;
         Vector3 point1, point2;
-        //Determine if we are colliding (or within skin width) of another object
-        //GetCapsuleInfoForAgent(myCollider, m_CharacterController.skinWidth, transform.position, out radius, out point1, out point2);
 
         //This method shoots a ray down from the agents head to find the highest point below the agent that is touching the ground and uses that point as the base of the overlap check
         CapsuleCastInfoByShootingRayToFloor(out point1, out point2, out radius);
+        
+        //Determine if we are colliding (or within skin width) of another object
         Collider[] overlapColliders = Physics.OverlapCapsule(point1, point2, radius + (radius*0.5f), 1 << 8);
 
         //we divide by scale here because we are going to expand the scaled collider by this value

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -20,6 +20,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     public static float LYING_POSITION_Y = 0.1f;
     public static float LYING_COLLIDER_HEIGHT = 0.05f;
     public static float LYING_COLLIDER_CENTER = 0.15f;
+    public static float CAPSULE_COLLIDER_RADIUS = 0.251f;
 
     //This is an extra collider that slightly clips into the ground to ensure collision with objects of any size.
     //When lying down, the radius increases to simulate the expansion of the body when horizontal
@@ -277,6 +278,11 @@ public class MCSController : PhysicsRemoteFPSAgentController {
 
     public void OnSceneChange() {
         pose = PlayerPose.STANDING;
+        CapsuleCollider cc = GetComponent<CapsuleCollider>();
+        cc.height = STANDING_COLLIDER_HEIGHT;
+        cc.center = new Vector3(0,STANDING_COLLIDER_CENTER,0);
+        cc.radius = CAPSULE_COLLIDER_RADIUS;
+        groundObjectsCollider.radius = GROUND_OBJECTS_COLLIDER_RADIUS;
     }
 
     public void MCSCloseObject(ServerAction action) {

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -8,12 +8,15 @@ using System.Collections.Generic;
 public class MCSController : PhysicsRemoteFPSAgentController {
     public const float PHYSICS_SIMULATION_STEP_SECONDS = 0.01f;
 
-    //position y creates the pose
-    //collider height is adjusted for each pose to prevent clipping inside the floor, allow traversal under structures, and allow ramp ascension
-    //collider center shifts when the position y is changed for poses
+    //Position y creates the pose
+    //Collider height is adjusted for each pose to prevent clipping inside the floor, allow traversal under structures, and allow ramp ascension
+    //Collider center shifts when the position y is changed for poses
+    //These collider numbers were derived from the agents y position on pose changes by hand. 
+    //In an orthographic perspective, the value were shifted until the collider's bottom most point was touching the ground when on a flat surface, 
+    //and the topmost point was touching the tip of the agents head.
     public static float STANDING_POSITION_Y = 0.762f;
-    public static float STANDING_COLLIDER_HEIGHT = 1.23f; //1.3875f;
-    public static float STANDING_COLLIDER_CENTER = -0.33f; //-0.4625f;
+    public static float STANDING_COLLIDER_HEIGHT = 1.23f;
+    public static float STANDING_COLLIDER_CENTER = -0.33f;
     public static float CRAWLING_POSITION_Y = STANDING_POSITION_Y/2;
     public static float CRAWLING_COLLIDER_HEIGHT = 0.75f;
     public static float CRAWLING_COLLIDER_CENTER = -0.05f;
@@ -953,8 +956,7 @@ public class MCSController : PhysicsRemoteFPSAgentController {
                 myCollider.radius -= obstructionVsCollisionDifference;
                 Vector3 newPos = transform.position;
                 if (overlap) {
-                    float additionalPush = 1.25f; //for ramps this is necessary, otherwise the agent will hang off the side of the ramp and clip into it
-                    Vector3 shift = direction * (distance * additionalPush);
+                    Vector3 shift = direction * distance;
                     newPos += shift;
                     transform.position = newPos;
                 }

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -31,7 +31,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
         // Used to expand agent capsule in collision checks for open/close actions
         protected const float ExpandAgentCapsuleBy = 0.1f;
         protected bool canMove = true;
-        protected string inputDirection;
         protected float serverActionMoveMagnitude;
 
 

--- a/unity/ProjectSettings/GraphicsSettings.asset
+++ b/unity/ProjectSettings/GraphicsSettings.asset
@@ -44,6 +44,7 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 171e6e515a12e4a298dce708924e98ba, type: 3}
   - {fileID: 4800000, guid: 1871f0d3e57ff4b9dabfb43c8fc1ed93, type: 3}
   - {fileID: 4800000, guid: 4cf408482db174fc4b862238d304ef73, type: 3}
+  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
I made a capsule cast method that centers the bottom of the capsule cast by shooting a sphere cast to the floor and picking the highest point it hits rather than getting the min y of the collider. The agents capsule collider now shrinks and expands depending on the pose. I left the debugging gizmos as comments because they are extremely helpful visualizations for any future debugging.
*** 
The agent can ascend ramps at 50 degree angles. This is _**not**_ intentional and buggy and happens every other time it tries to ascend it. When making scenes for eval tests, we should not have any ramps  **46 > x < 59**.
**<= 45** always works the agent will ascend
**>= 60** always prevents the agent from moving as intended 