### PR TITLE
Picking up static containers when switched to a pickupable object throws nre exception fixed

### DIFF
--- a/unity/Assets/Scripts/Contains.cs
+++ b/unity/Assets/Scripts/Contains.cs
@@ -491,7 +491,7 @@ public class Contains : MonoBehaviour
 	}
 
     public Vector3 FindReceptacleTriggerBoxSize() {
-        GameObject simObj = gameObject.GetComponentInParent<SimObjPhysics>().gameObject;
+        GameObject simObj = myParent;
         // Sometimes the receptacle trigger box has a component between itself and the SimObjPhysics object.
         GameObject parentObject = (gameObject.transform.parent.gameObject.GetInstanceID() == simObj.GetInstanceID()) ?
             null : gameObject.transform.parent.gameObject;


### PR DESCRIPTION
The bug was if chest_1 was switched to pickupable and you tried to pick it up, it would throw an nre. Normally it is a static object but in the case it or any similar static objects like it need this property, this will fix it.