### PR TITLE
Fix bug with segmentation masks

### DIFF
--- a/unity/Assets/ImageSynthesis/ImageSynthesis.cs
+++ b/unity/Assets/ImageSynthesis/ImageSynthesis.cs
@@ -335,7 +335,7 @@ public class ImageSynthesis : MonoBehaviour {
 
 
 			Color classColor = ColorEncoding.EncodeTagAsColor (classTag);
-			Color objColor = ColorEncoding.EncodeTagAsColor(objTag);
+			Color objColor = ColorEncoding.EncodeTagAsColor(objTag + guidForColors);
 
             if (capturePasses[0].camera != null) {
 			    capturePasses [0].camera.WorldToScreenPoint (r.bounds.center);


### PR DESCRIPTION
When testing metadata level enums on the python API, I noticed that colors in the segmentation masks were no longer being randomized for level2 metadata. Noticed it was broken in 0.4.3 as well (may have happened in the ai2thor upgrade?) 

Ended up being an easy fix. It may impact the color map ticket as well. 