### PR TITLE
MCS-889 Trying to Close, Open, or Place using the floor/wall now returns NOT_INTERACTABLE rather than NOT_RECEPTACLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ For playback:
   - In `isAgentCapsuleCollidingWith`, added expandBy parameter.
   - Added `isAgentOnTopOfObject` function to check for obstructions when opening objects that slide out (like drawers).
   - Change the layer of the `ItemInHand` to `SimObjInvisible` when picked up and to `SimObjVisible` when put/dropped/thrown.
+  - Reorganized `PlaceHeldObject`, `OpenObject`, and `CloseObject` to return the most relevant action status.
 - `Scripts/PhysicsSceneManager`:
   - Added `virtual` to functions: `Generate_UniqueID`
 - `Scripts/SimObjPhysics`:

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -4231,7 +4231,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             SimObjPhysics targetReceptacle = physicsSceneManager.ObjectIdToSimObjPhysics[action.receptacleObjectId];
 
-            if (targetReceptacle == null || !targetReceptacle.GetComponent<SimObjPhysics>()) {
+            if (targetReceptacle == null || !targetReceptacle.GetComponent<SimObjPhysics>() || targetReceptacle.GetComponent<StructureObject>()) {
                 errorMessage = action.receptacleObjectId + " is not interactable.";
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
                 actionFinished(false);
@@ -4973,7 +4973,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             SimObjPhysics target = physicsSceneManager.ObjectIdToSimObjPhysics[action.objectId];
 
-            if (target == null || !target.GetComponent<SimObjPhysics>()) {
+            if (target == null || !target.GetComponent<SimObjPhysics>() || target.GetComponent<StructureObject>()) {
                 errorMessage = action.objectId + " is not interactable.";
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
                 actionFinished(false);
@@ -5790,7 +5790,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
 
             SimObjPhysics target = physicsSceneManager.ObjectIdToSimObjPhysics[action.objectId];
 
-            if (target == null || !target.GetComponent<SimObjPhysics>()) {
+            if (target == null || !target.GetComponent<SimObjPhysics>() || target.GetComponent<StructureObject>()) {
                 errorMessage = action.objectId + " is not interactable.";
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_INTERACTABLE);
                 actionFinished(false);


### PR DESCRIPTION
Notes:
- Since dropping/throwing/placing devices are also currently tagged as structural objects, returning NOT_OBJECT seemed potentially confusing, which is why I chose NOT_INTERACTABLE instead.
- Returning OUT_OF_REACH is its own bag of worms...

Corresponding Python PR: https://github.com/NextCenturyCorporation/MCS/pull/407