### PR TITLE
Making robot body invisible (MCS-912).

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -151,6 +151,9 @@ public class MCSMain : MonoBehaviour {
                 MCSMain.LATEST_SCENE_VERSION);
         }
 
+        // Make robot body invisible
+        GameObject.Find("VisibilityCapsule").SetActive(false);
+
         // We should always have debug logs enabled in debug builds.
         if (Debug.isDebugBuild) {
             Debug.unityLogger.logEnabled = true;


### PR DESCRIPTION
Small fix to hide the robot's body per discussions in Teams/Slack. Tested pickup/dropping objects within Unity, ran integration tests, and took a look at the depth and segmentation maps -- everything seemed fine. Also checked first frame per Erick's comment in slack to make sure it didn't take a frame to not render the robot (I just took a scene file and updated the rotation so the camera was pointing straight down at start).