### PR TITLE
Fixed a bug with incorrect friction in intuitive physics scenes.

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -364,15 +364,14 @@ public class MCSMain : MonoBehaviour {
             this.currentScene.performerStart.position.z = MCSMain.INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Z;
             this.currentScene.performerStart.rotation = new MCSConfigVector();
 
-            if (this.currentScene.floorProperties == null || !this.currentScene.floorProperties.enable) {
-                this.currentScene.floorProperties = new MCSConfigPhysicsProperties();
-                this.currentScene.floorProperties.enable = true;
-                this.currentScene.floorProperties.dynamicFriction = MCSMain.PHYSICS_FRICTION_DYNAMIC_PASSIVE;
-                this.currentScene.floorProperties.staticFriction = MCSMain.PHYSICS_FRICTION_STATIC_PASSIVE;
-                this.currentScene.floorProperties.bounciness = MCSMain.PHYSICS_BOUNCINESS_DEFAULT;
-                this.currentScene.floorProperties.drag = MCSMain.RIGIDBODY_DRAG_DEFAULT;
-                this.currentScene.floorProperties.angularDrag = MCSMain.RIGIDBODY_ANGULAR_DRAG_DEFAULT;
-            }
+            // Override the default or configured floorProperties for all intuitivePhysics scenes.
+            this.currentScene.floorProperties = new MCSConfigPhysicsProperties();
+            this.currentScene.floorProperties.enable = true;
+            this.currentScene.floorProperties.dynamicFriction = MCSMain.PHYSICS_FRICTION_DYNAMIC_PASSIVE;
+            this.currentScene.floorProperties.staticFriction = MCSMain.PHYSICS_FRICTION_STATIC_PASSIVE;
+            this.currentScene.floorProperties.bounciness = MCSMain.PHYSICS_BOUNCINESS_DEFAULT;
+            this.currentScene.floorProperties.drag = MCSMain.RIGIDBODY_DRAG_DEFAULT;
+            this.currentScene.floorProperties.angularDrag = MCSMain.RIGIDBODY_ANGULAR_DRAG_DEFAULT;
         } else if (this.currentScene.isometric) {
             this.currentScene.performerStart = new MCSConfigTransform();
             this.currentScene.performerStart.position = new MCSConfigVector();


### PR DESCRIPTION
Always override floor properties in intuitive physics scenes. Without using the expected friction values, objects don't move correctly (for example, objects that are supposed to exit the scene may not), and they may not be in the correct position when their implausible event occurs.

I've added MCS-570 into the sprint to add integration tests that verify object movement in intuitive physics scenes.

Here's an example scene (change extension from `.txt` to `.json`):
[eval_4_validation_spatio_temporal_continuity_0001_01.txt](https://github.com/NextCenturyCorporation/ai2thor/files/7282261/eval_4_validation_spatio_temporal_continuity_0001_01.txt)
