### PR TITLE
Close, Open, and Push object errors thrown reordering

### DIFF
--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -5903,7 +5903,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         OpenOrCloseObject(codd, previousOpenPercent);
                     }
                 }
-            } 
+            }
             else {
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OPENABLE);
                 errorMessage = "Object " + action.objectId + " is not openable.";

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -1872,14 +1872,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            bool canbepushed = false;
-
-            if (target.PrimaryProperty == SimObjPrimaryProperty.CanPickup ||
-                target.PrimaryProperty == SimObjPrimaryProperty.Moveable)
-                canbepushed = true;
-
-            if (!canbepushed) {
-                errorMessage = "Target Sim Object cannot be moved. It's primary property must be Pickupable or Moveable";
+            if (target.GetComponent<StructureObject>() != null) {
+                errorMessage = "Target is Structure object and cannot be moved. Target's primary property must be Pickupable or Moveable and not a Structure";
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_MOVEABLE);
                 actionFinished(false);
                 return;
@@ -1904,6 +1898,18 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 Debug.Log(errorMessage);
                 Debug.Log(string.Format("Agent - X position: {0} - Z position {1}.", player.transform.position.x, player.transform.position.z));
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
+                actionFinished(false);
+                return;
+            }
+
+            bool canbepushed = false;
+            if (target.PrimaryProperty == SimObjPrimaryProperty.CanPickup ||
+                target.PrimaryProperty == SimObjPrimaryProperty.Moveable)
+                canbepushed = true;
+
+            if (!canbepushed) {
+                errorMessage = "Target Sim Object cannot be moved. It's primary property must be Pickupable or Moveable";
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_MOVEABLE);
                 actionFinished(false);
                 return;
             }
@@ -4980,13 +4986,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            if (!target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanOpen)) {
-                errorMessage = "This target object is NOT openable!";
-                Debug.Log(errorMessage);
-                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OPENABLE);
-                actionFinished(false);
-                return;
-            }
 
             target = null;
 
@@ -5009,6 +5008,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (visibleObjects.Length == 0) {
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
                 errorMessage = "Object " + action.objectId + " is not within reach or is not really an object.";
+                actionFinished(false);
+                return;
+            }
+
+            if (target != null && !target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanOpen)) {
+                errorMessage = "This target object is NOT openable!";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OPENABLE);
                 actionFinished(false);
                 return;
             }
@@ -5797,13 +5804,6 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                 return;
             }
 
-            if (!target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanOpen)) {
-                errorMessage = "This target object is NOT openable!";
-                Debug.Log(errorMessage);
-                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OPENABLE);
-                actionFinished(false);
-                return;
-            }
 
             target = null;
 
@@ -5826,6 +5826,14 @@ namespace UnityStandardAssets.Characters.FirstPerson {
             if (visibleObjects.Length == 0) {
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.OUT_OF_REACH);
                 errorMessage = "Object " + action.objectId + " is not within reach or is not really an object.";
+                actionFinished(false);
+                return;
+            }
+
+            if (target != null && !target.DoesThisObjectHaveThisSecondaryProperty(SimObjSecondaryProperty.CanOpen)) {
+                errorMessage = "This target object is NOT openable!";
+                Debug.Log(errorMessage);
+                this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OPENABLE);
                 actionFinished(false);
                 return;
             }
@@ -5896,6 +5904,8 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                     }
                 }
             }
+
+            
             else {
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OPENABLE);
                 errorMessage = "Object " + action.objectId + " is not openable.";

--- a/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
+++ b/unity/Assets/Scripts/PhysicsRemoteFPSAgentController.cs
@@ -5903,9 +5903,7 @@ namespace UnityStandardAssets.Characters.FirstPerson {
                         OpenOrCloseObject(codd, previousOpenPercent);
                     }
                 }
-            }
-
-            
+            } 
             else {
                 this.lastActionStatus = Enum.GetName(typeof(ActionStatus), ActionStatus.NOT_OPENABLE);
                 errorMessage = "Object " + action.objectId + " is not openable.";


### PR DESCRIPTION
It seems like the Push/Pull action wasn't totally fixed either so I edited that based on the conversation in [teams](https://gov.teams.microsoft.us/l/message/19:gcch:959d7221399c4fe08b3ac2def85e1f0d@thread.skype/1642084651235?tenantId=74cf14f4-38e0-460b-9d96-c0a51cb4a55c&groupId=bd0afc79-5b79-4a03-a04a-00fc785501de&parentMessageId=1642021197022&teamName=PIAGET%20(MCS)&channelName=MCS%20Technical&createdTime=1642084651235) making structural objects always say not moveable while non-movable sim objects throw out of reach first then 'not moveable' once you're close enough. 

My reordering the code around solution for Open/Close seemed a little more straight forward than the [ticket ](https://nextcentury.atlassian.net/jira/software/projects/MCS/boards/94?selectedIssue=MCS-499) made it out to be. Maybe I missed something but it appears to work as intended.