### PR TITLE
Seesaw being vertical during integration tests bug fix

### DIFF
--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -224,6 +224,8 @@ public class PhysicsSceneManager : MonoBehaviour
 		}
 
 		BaseFPSAgentController fpsController =  GameObject.FindObjectOfType<BaseFPSAgentController>();
+		foreach(Collider c in fpsController.GetComponents<Collider>())
+            c.enabled = false;
 		if (fpsController.imageSynthesis != null) {
 			fpsController.imageSynthesis.OnSceneChange();
 		}


### PR DESCRIPTION
[Ticket ](https://nextcentury.atlassian.net/browse/MCS-848?atlOrigin=eyJpIjoiZTJiY2U4MDQzMmFhNGQ2NTlhMGM0N2RlYTNmOWMyN2IiLCJwIjoiaiJ9)

I disabled and enabled the colliders of the agent on scene changes. The bug was caused by the agent clipping into the seesaw and bumping it during scene setup.