### PR TITLE
Seesaws being vertical during integration testing bug fix

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -284,6 +284,8 @@ public class MCSMain : MonoBehaviour {
         GameObject controller = GameObject.Find("FPSController");
         controller.GetComponent<Rigidbody>().velocity = Vector3.zero;
         controller.GetComponent<Rigidbody>().angularVelocity = Vector3.zero;
+        foreach(Collider c in controller.GetComponents<Collider>())
+            c.enabled = false;
         if (this.currentScene.performerStart != null && this.currentScene.performerStart.position != null) {
             // Always keep the Y position on the floor.
             controller.transform.position = new Vector3(this.currentScene.performerStart.position.x,

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -224,6 +224,8 @@ public class PhysicsSceneManager : MonoBehaviour
 		}
 
 		BaseFPSAgentController fpsController =  GameObject.FindObjectOfType<BaseFPSAgentController>();
+		foreach(Collider c in fpsController.GetComponents<Collider>())
+            c.enabled = false;
 		if (fpsController.imageSynthesis != null) {
 			fpsController.imageSynthesis.OnSceneChange();
 		}

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 //using UnityEditor;
@@ -225,7 +225,7 @@ public class PhysicsSceneManager : MonoBehaviour
 
 		BaseFPSAgentController fpsController =  GameObject.FindObjectOfType<BaseFPSAgentController>();
 		foreach(Collider c in fpsController.GetComponents<Collider>())
-            c.enabled = true;
+        	c.enabled = true;
 		if (fpsController.imageSynthesis != null) {
 			fpsController.imageSynthesis.OnSceneChange();
 		}

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -225,7 +225,7 @@ public class PhysicsSceneManager : MonoBehaviour
 
 		BaseFPSAgentController fpsController =  GameObject.FindObjectOfType<BaseFPSAgentController>();
 		foreach(Collider c in fpsController.GetComponents<Collider>())
-            c.enabled = false;
+            c.enabled = true;
 		if (fpsController.imageSynthesis != null) {
 			fpsController.imageSynthesis.OnSceneChange();
 		}

--- a/unity/Assets/Scripts/PhysicsSceneManager.cs
+++ b/unity/Assets/Scripts/PhysicsSceneManager.cs
@@ -225,7 +225,7 @@ public class PhysicsSceneManager : MonoBehaviour
 
 		BaseFPSAgentController fpsController =  GameObject.FindObjectOfType<BaseFPSAgentController>();
 		foreach(Collider c in fpsController.GetComponents<Collider>())
-        	c.enabled = true;
+			c.enabled = true;
 		if (fpsController.imageSynthesis != null) {
 			fpsController.imageSynthesis.OnSceneChange();
 		}


### PR DESCRIPTION
Corresponding [MCS PR](https://github.com/NextCenturyCorporation/MCS/pull/465)

To replicate switch your MCS branch to **MCS-848-Testing-Example**. Run those tests with a build that was **NOT** built from **MCS-848**. Then make a **MCS-848** build and re-run the tests. The bug should be fixed.

This fix just deactivates and activates the agents colliders between scene changes so that SimObjects are placed first then the agents colliders are activated. It seemed like depending on the agents location between scene changes, if the agent was inside where a seesaw would be placed, that one frame would clip the seesaw into the agent and cause it to collide irrationally. 