### PR TITLE
Haptic feedback for lava and step output

### DIFF
--- a/unity/Assets/Addressables/MCS/Scenes/lava.json
+++ b/unity/Assets/Addressables/MCS/Scenes/lava.json
@@ -1,0 +1,41 @@
+{
+  "name": "lava",
+  "version": 2,
+  "ceilingMaterial": "AI2-THOR/Materials/Walls/Drywall",
+  "floorMaterial": "AI2-THOR/Materials/Fabrics/CarpetWhite 3",
+  "wallMaterial": "AI2-THOR/Materials/Walls/Drywall",
+  "roomDimensions": {
+      "x": 5,
+      "y": 5,
+      "z": 8
+  },
+  "floorTextures": [{
+      "material": "Stylized Lava Texture/Materials/Stylize_Lava_diffuse",
+      "positions": [{
+              "x": 0,
+              "z": 1
+          }, {
+              "x": 1,
+              "z": 2
+          }]
+  }, {
+      "material": "AI2-THOR/Materials/Wood/WornWood",
+      "positions": [{
+              "x": 2,
+              "z": 1
+          }, {
+              "x": -2,
+              "z": 1
+          }
+  ]}],
+  "performerStart": {
+      "position": {
+          "x": 0,
+          "z": 0
+      },
+      "rotation": {
+          "x": 0,
+          "y": 0
+      }
+  }
+}

--- a/unity/Assets/Addressables/MCS/Scenes/lava.json.meta
+++ b/unity/Assets/Addressables/MCS/Scenes/lava.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 421ba369cf71f1326802b78ee81b0166
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1339,6 +1339,7 @@ public struct MetadataWrapper
     public float performerReach;
     public string pose;
 	public float performerRadius;
+	public string[] hapticFeedback;
 }
 
 [Serializable]

--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1339,7 +1339,7 @@ public struct MetadataWrapper
     public float performerReach;
     public string pose;
 	public float performerRadius;
-	public string[] hapticFeedback;
+	public Dictionary<string, bool> hapticFeedback;
 }
 
 [Serializable]

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -569,7 +569,10 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             RotateLookBodyAcrossFrames(this.bodyRotationActionData);
             actionFinished(true);
         }
+        //haptic feedback checks
+        hapticFeedback.Clear();
         CheckIfInLava();
+
         // Call Physics.Simulate multiple times with a small step value because a large step
         // value causes collision errors.  From the Unity Physics.Simulate documentation:
         // "Using step values greater than 0.03 is likely to produce inaccurate results."   
@@ -580,8 +583,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     }
 
     private void CheckIfInLava() {
-        hapticFeedback.Clear();
-        
         Ray ray = new Ray(transform.position, Vector3.down);
         RaycastHit hit;
         Physics.SphereCast(transform.position, AGENT_RADIUS, Vector3.down, out hit, AGENT_STARTING_HEIGHT + 0.01f, 1<<8, QueryTriggerInteraction.Ignore);

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -211,7 +211,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         metadata.clippingPlaneNear = this.m_Camera.nearClipPlane;
         metadata.performerRadius = this.GetComponent<CapsuleCollider>().radius;
         metadata.hapticFeedback = this.hapticFeedback.Select(hf => hf.ToString()).ToArray();
-        Debug.Log(metadata.hapticFeedback);
         metadata.structuralObjects = metadata.objects.ToList().Where(objectMetadata => {
             GameObject gameObject = GameObject.Find(objectMetadata.name);
             // The object may be null if it is being held.

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -59,10 +59,9 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     private MCSRotationData lookRotationActionData; //stores look rotation direction
 
     private enum HapticFeedback {
-        LAVA,
-        SAFE
+        ON_LAVA,
     }
-    private List<HapticFeedback> hapticFeedback = new List<HapticFeedback> { HapticFeedback.SAFE };
+    private List<HapticFeedback> hapticFeedback = new List<HapticFeedback>();
 
 
     public override void CloseObject(ServerAction action) {
@@ -582,14 +581,19 @@ public class MCSController : PhysicsRemoteFPSAgentController {
 
     private void CheckIfInLava() {
         hapticFeedback.Clear();
+        
         Ray ray = new Ray(transform.position, Vector3.down);
         RaycastHit hit;
         Physics.SphereCast(transform.position, AGENT_RADIUS, Vector3.down, out hit, AGENT_STARTING_HEIGHT + 0.01f, 1<<8, QueryTriggerInteraction.Ignore);
         Material material = hit.transform.GetComponent<Renderer>().material;
-        if(material != null && material.name.Contains("Stylize_Lava"))
-            hapticFeedback.Add(HapticFeedback.LAVA);
-        else
-            hapticFeedback.Add(HapticFeedback.SAFE);
+        
+        //this is at the end of every material name
+        string materialInstanceString = " (Instance)";
+        string materialName = material.name.Substring(0, material.name.Length - materialInstanceString.Length);
+
+        if(material != null && MCSConfig.LAVA_MATERIAL_REGISTRY.Any(key=>key.Key.Contains(materialName))) {
+            hapticFeedback.Add(HapticFeedback.ON_LAVA);
+        }
     }
 
     private IEnumerator SimulatePhysicsSaveImagesIncreaseStep() {


### PR DESCRIPTION
[MCS](https://github.com/NextCenturyCorporation/MCS/pull/472)

Lava detection is based on the agents collider radius. This means from the agents perspective it is **not** always directly on top of lava when receiving lava haptic feedback. The lava detection radius can be easily adjusted if we want it bigger or smaller. The way haptic feedback is implemented here leaves flexibility for future haptic feedbacks to happen simultaneously.