### PR TITLE
MCS-1151 Various Block Tool Improvements

### DIFF
--- a/unity/Assets/Addressables/MCS/primitive_object_registry.json
+++ b/unity/Assets/Addressables/MCS/primitive_object_registry.json
@@ -312,6 +312,96 @@
             "z": 0
         }]
     }, {
+        "id": "cube_rounded",
+        "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cube_02",
+        "shape": "cube",
+        "mass": 1,
+        "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+        },
+        "physicsProperties": {
+            "enable": true,
+            "dynamicFriction": 0.6,
+            "staticFriction": 0.6,
+            "bounciness": 0.75,
+            "drag": 0,
+            "angularDrag": 0.5
+        },
+        "boundingBox": {
+            "position": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "scale": {
+                "x": 1,
+                "y": 1,
+                "z": 1
+            }
+        },
+        "colliders": [{
+            "type": "mesh"
+        }],
+        "visibilityPoints": [{
+            "x": -0.5,
+            "y": -0.5,
+            "z": -0.5
+        }, {
+            "x": 0.5,
+            "y": -0.5,
+            "z": -0.5
+        }, {
+            "x": 0.5,
+            "y": -0.5,
+            "z": 0.5
+        }, {
+            "x": -0.5,
+            "y": -0.5,
+            "z": 0.5
+        }, {
+            "x": -0.5,
+            "y": 0.5,
+            "z": -0.5
+        }, {
+            "x": -0.5,
+            "y": 0.5,
+            "z": 0.5
+        }, {
+            "x": 0.5,
+            "y": 0.5,
+            "z": 0.5
+        }, {
+            "x": 0.5,
+            "y": 0.5,
+            "z": -0.5
+        }, {
+            "x": 0.5,
+            "y": 0,
+            "z": 0
+        }, {
+            "x": -0.5,
+            "y": 0,
+            "z": 0
+        }, {
+            "x": 0,
+            "y": 0,
+            "z": 0.5
+        }, {
+            "x": 0,
+            "y": 0,
+            "z": -0.5
+        }, {
+            "x": 0,
+            "y": 0.5,
+            "z": 0
+        }, {
+            "x": 0,
+            "y": -0.5,
+            "z": 0
+        }]
+    }, {
         "id": "cylinder",
         "resourceFile": "UnityAssetStore/proPrototypeCollection/Prefabs/cylinder_01",
         "shape": "cylinder",


### PR DESCRIPTION
Implemented various improvements to support pushable block tools:
- Added a new cube shape with rounded corners. Helps make pushing smoother.
- Auto generate visibility points for all cubes in interactive scenes. Previously cubes were assigned a limited number of visibility points, which were stretched across the entire cube, even when the cube was scaled up. This made pushing difficult, because the proximity of the nearest visibility point is used to determine if an object is "in reach".