### PR TITLE
MCS-1160 Added option for impulse force to MCS object config schema (Unity)

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -1668,10 +1668,11 @@ public class MCSMain : MonoBehaviour {
         objectConfig.forces.Where(force => force.vector != null && WithinInterval(force, step))
             .ToList().ForEach((force) => {
                 if (rigidbody != null) {
+                    ForceMode forceMode = force.impulse ? ForceMode.Impulse : ForceMode.Force;
                     if (force.relative) {
-                        rigidbody.AddRelativeForce(new Vector3(force.vector.x, force.vector.y, force.vector.z));
+                        rigidbody.AddRelativeForce(new Vector3(force.vector.x, force.vector.y, force.vector.z), forceMode);
                     } else {
-                        rigidbody.AddForce(new Vector3(force.vector.x, force.vector.y, force.vector.z));
+                        rigidbody.AddForce(new Vector3(force.vector.x, force.vector.y, force.vector.z), forceMode);
                     }
                 }
             });
@@ -1887,6 +1888,7 @@ public class MCSConfigInteractables {
 
 [Serializable]
 public class MCSConfigForce : MCSConfigMove {
+    public bool impulse;
     public bool relative;
 }
 


### PR DESCRIPTION
Corresponding Python PR: https://github.com/NextCenturyCorporation/MCS/pull/496

Impulse force will be useful for throwing the soccer ball in the "moving target" task, and possibly other tasks in the future.