### PR TITLE
Ignore checking for agent being on lava for passive scenes.

### DIFF
--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -604,9 +604,14 @@ public class MCSController : PhysicsRemoteFPSAgentController {
     }
 
     private void CheckIfInLava() {
+        MCSMain main = GameObject.Find("MCS").GetComponent<MCSMain>();
+        if (main.isPassiveScene) {
+            return;
+        }
         Ray ray = new Ray(transform.position, Vector3.down);
         RaycastHit hit;
         Physics.SphereCast(transform.position, AGENT_RADIUS, Vector3.down, out hit, AGENT_STARTING_HEIGHT + 0.01f, 1<<8, QueryTriggerInteraction.Ignore);
+
         Renderer renderer = hit.transform.GetComponent<Renderer>();
         if(renderer!=null) {
             Material material = renderer.material;

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -611,7 +611,6 @@ public class MCSController : PhysicsRemoteFPSAgentController {
         Ray ray = new Ray(transform.position, Vector3.down);
         RaycastHit hit;
         Physics.SphereCast(transform.position, AGENT_RADIUS, Vector3.down, out hit, AGENT_STARTING_HEIGHT + 0.01f, 1<<8, QueryTriggerInteraction.Ignore);
-
         Renderer renderer = hit.transform.GetComponent<Renderer>();
         if(renderer!=null) {
             Material material = renderer.material;


### PR DESCRIPTION
Tried an eval 4 passive scene for testing and realized  it was broken. Tracked the issue to CheckIfInLava(), where hit.transform was null and throwing an exception because its not accounting for the different performer height in passive scenes. Since I don't think we'll need to worry about lava in passive scenes, skipping that check entirely in that case. 