### PR TITLE
MCS-1253 Changed default drag of soccer ball.

### DIFF
--- a/unity/Assets/Addressables/MCS/mcs_object_registry.json
+++ b/unity/Assets/Addressables/MCS/mcs_object_registry.json
@@ -132,7 +132,7 @@
             "dynamicFriction": 0.25,
             "staticFriction": 0.25,
             "bounciness": 0.75,
-            "drag": 0,
+            "drag": 0.25,
             "angularDrag": 0.5
         },
         "boundingBox": {


### PR DESCRIPTION
Getting this out before sprint planning. I want to do a bit more testing but I think this is the only change that's needed. Once I finish sorting out some issues with my locally-built addressables, I'll update the integration tests accordingly.

When this branch is finalized, approved, and merged, we can simply cherry-pick this commit and merge it into `master` as well, to rebuild the main asset bundles and "release" the modified soccer ball.