### PR TITLE
Fixed a bug in which non-agents were incorrectly set as kinematic.

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -1446,8 +1446,10 @@ public class MCSMain : MonoBehaviour {
                 }
             }
         }
-        if(objectConfig.agentSettings != null)
+
+        if(objectDefinition.agent) {
             ai2thorPhysicsScript.GetComponent<Rigidbody>().isKinematic = true;
+        }
 
         if(objectConfig.associatedWithAgent != null && objectConfig.associatedWithAgent.Length > 0) {
             if(ai2thorPhysicsScript.shape != "ball") {


### PR DESCRIPTION
This was happening while running scenes in the Unity Editor. I'm guessing, when run via Python, `agentSettings` defaults to null, but when run in the Unity Editor, it doesn't.