### PR TITLE
Fixed issue with super big far clipping plane.

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -338,7 +338,11 @@ public class MCSMain : MonoBehaviour {
             }
         }
 
-        agentController.m_Camera.nearClipPlane = 0.011f;
+        // Update the camera properties to "reset" the camera and fix a weird rendering issue.
+        // Please note it's important to avoid arbitrarily changing the clipping plane values.
+        // We use them on the Python side for depth map data conversions, and AIs also use them.
+        agentController.m_Camera.nearClipPlane = 0.01f;
+        agentController.m_Camera.farClipPlane = 150f;
         
         this.lastStep = -1;
         this.physicsSceneManager.SetupScene();


### PR DESCRIPTION
I noticed the far clipping plane was getting set somewhere to `9999`, which is much bigger than we'd ever need. I changed it back to its previous value (`150`, which allows you to see corner-to-corner across a 100x100 size room), and added a comment about why it's important. I also added a comment about the need to "reset" the camera (from Jacob's PR that he recently merged). Please let me know if you have any questions or concerns about the behavior.