### PR TITLE
MCS-1320 Fixed a bug in which agent head skin color was never being properly set

### DIFF
--- a/unity/Assets/Scripts/MCSSimulationAgent.cs
+++ b/unity/Assets/Scripts/MCSSimulationAgent.cs
@@ -784,9 +784,7 @@ public class MCSSimulationAgent : MonoBehaviour {
         if (facelessHead != null) {
             this.SetMaterial(facelessHead, skinIndex);
         }
-        else {
-            this.SetSkinMaterial(new SkinObjectMaterialOption[]{this.head}, skinOptions, this.skin);
-        }
+        this.SetSkinMaterial(new SkinObjectMaterialOption[]{this.head}, skinOptions, this.skin);
         this.SetSkinMaterial(this.chestOptions, skinOptions, this.skin);
         this.SetSkinMaterial(this.feetOptions, skinOptions, this.skin);
         this.SetSkinMaterial(this.legsOptions, skinOptions, this.skin);


### PR DESCRIPTION
Currently, the skin on an agent's head remains light colored (the default), even when the skin on the rest of the body is set to a different color. This is because `facelessHead` is always non-null after initialization, even when the agent isn't "faceless" (the `facelessHead` is just inactive), so the `else` wasn't triggering. I don't believe this issue is critical enough on its own to demand a post-feature-freeze release.