### PR TITLE
MCS-1333 Updated passive physics scene properties for Eval 5.

### DIFF
--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -18,11 +18,11 @@ public class MCSMain : MonoBehaviour {
     private static float AUTO_GRID_CELL_MIN = 2f;
     private static float AUTO_GRID_CELL_SPACING = 0.25f;
     private static float AUTO_GRID_HALF_SCALE = 0.5f;
-    private static float FLOOR_SCALE_X = 11f;
     private static float FLOOR_SCALE_Y = 0.5f;
-    private static float FLOOR_SCALE_Z = 11f;
     private static float INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Y = 1.5f;
     private static float INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Z = -4.5f;
+    private static float INTUITIVE_PHYSICS_SPOT_LIGHT_RANGE = 15f;
+    private static float INTUITIVE_PHYSICS_SPOT_LIGHT_RANGE_OLD = 10f;
     private static float ISOMETRIC_FLOOR_SCALE_XZ = 9f;
     private static float ISOMETRIC_PERFORMER_START_POSITION_X = 4f;
     private static float ISOMETRIC_PERFORMER_START_POSITION_Y = 3f;
@@ -58,7 +58,6 @@ public class MCSMain : MonoBehaviour {
     private static float RIGIDBODY_ANGULAR_DRAG_DEFAULT = 0.5f;
     private static float WALL_BACK_FRONT_POSITION_X = 0;
     private static float WALL_LEFT_RIGHT_POSITION_Z = 0;
-    private static float WALL_LEFT_RIGHT_SCALE_Z = 11.0f;
     private static float WALL_WIDTH = 0.5f;
     private static Vector3 DEFAULT_ROOM_DIMENSIONS = new Vector3(10, 3, 10);
     private static Vector3 DEFAULT_ROOM_DIMENSIONS_INTUITIVE_PHYSICS_OLD = new Vector3(15, 6, 10);
@@ -821,6 +820,9 @@ public class MCSMain : MonoBehaviour {
         this.currentScene.floorProperties.angularDrag = MCSMain.RIGIDBODY_ANGULAR_DRAG_DEFAULT;
 
         this.currentScene.wallProperties = null;
+
+        this.light2.GetComponent<Light>().range = oldScene ? INTUITIVE_PHYSICS_SPOT_LIGHT_RANGE_OLD :
+            INTUITIVE_PHYSICS_SPOT_LIGHT_RANGE;
     }
 
     private void SetupIsometric() {

--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -21,14 +21,8 @@ public class MCSMain : MonoBehaviour {
     private static float FLOOR_SCALE_X = 11f;
     private static float FLOOR_SCALE_Y = 0.5f;
     private static float FLOOR_SCALE_Z = 11f;
-    private static float INTUITIVE_PHYSICS_FLOOR_SCALE_X = 15f;
     private static float INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Y = 1.5f;
     private static float INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Z = -4.5f;
-    private static float INTUITIVE_PHYSICS_WALL_BACK_FRONT_SCALE_X = 15f;
-    private static float INTUITIVE_PHYSICS_WALL_FRONT_POSITION_Y = 3f;
-    private static float INTUITIVE_PHYSICS_WALL_FRONT_SCALE_Y = 6f;
-    private static float INTUITIVE_PHYSICS_WALL_LEFT_POSITION_X = -7.5f;
-    private static float INTUITIVE_PHYSICS_WALL_RIGHT_POSITION_X = 7.5f;
     private static float ISOMETRIC_FLOOR_SCALE_XZ = 9f;
     private static float ISOMETRIC_PERFORMER_START_POSITION_X = 4f;
     private static float ISOMETRIC_PERFORMER_START_POSITION_Y = 3f;
@@ -56,27 +50,20 @@ public class MCSMain : MonoBehaviour {
     private static Color LIGHT_DEFAULT_COLOR = Color.white;
     private static int MIN_ROOM_DIMENSIONS_FOR_ADDITIONAL_LIGHTS = 12;
     private static float PHYSICS_FRICTION_DYNAMIC_DEFAULT = 0.6f;
-    private static float PHYSICS_FRICTION_DYNAMIC_PASSIVE = 0.1f;
+    private static float PHYSICS_FRICTION_DYNAMIC_INTUITIVE_PHYSICS = 0.1f;
     private static float PHYSICS_FRICTION_STATIC_DEFAULT = 0.6f;
-    private static float PHYSICS_FRICTION_STATIC_PASSIVE = 0.1f;
+    private static float PHYSICS_FRICTION_STATIC_INTUITIVE_PHYSICS = 0.1f;
     private static float PHYSICS_BOUNCINESS_DEFAULT = 0;
     private static float RIGIDBODY_DRAG_DEFAULT = 0;
     private static float RIGIDBODY_ANGULAR_DRAG_DEFAULT = 0.5f;
     private static float WALL_BACK_FRONT_POSITION_X = 0;
-    private static float WALL_BACK_FRONT_SCALE_X = 11.0f;
-    private static float WALL_BACK_FRONT_SCALE_Z = 0.5f;
-    private static float WALL_BACK_POSITION_Z = -5.25f;
-    private static float WALL_FRONT_POSITION_Z = 5.25f;
-    private static float WALL_LEFT_POSITION_X = -5.25f;
     private static float WALL_LEFT_RIGHT_POSITION_Z = 0;
-    private static float WALL_LEFT_RIGHT_SCALE_X = 0.5f;
     private static float WALL_LEFT_RIGHT_SCALE_Z = 11.0f;
-    private static float WALL_POSITION_Y = 1.5f;
-    private static float WALL_RIGHT_POSITION_X = 5.25f;
-    private static float WALL_SCALE_Y = 3.0f;
+    private static float WALL_WIDTH = 0.5f;
     private static Vector3 DEFAULT_ROOM_DIMENSIONS = new Vector3(10, 3, 10);
+    private static Vector3 DEFAULT_ROOM_DIMENSIONS_INTUITIVE_PHYSICS_OLD = new Vector3(15, 6, 10);
+    private static Vector3 DEFAULT_ROOM_DIMENSIONS_INTUITIVE_PHYSICS = new Vector3(20, 10, 20);
     private static Vector3 DEFAULT_FLOOR_POSITION = new Vector3(0, -0.25f, 0);
-    private static float WALL_WIDTH = .5f;
     private static int FLOOR_DEPTH = 6;
     private static int FLOOR_DIMENSIONS = 1;
     private static int FLOOR_LOWERED_HEIGHT = -100;
@@ -385,7 +372,6 @@ public class MCSMain : MonoBehaviour {
         // Remove the ceiling from all intuitive physics and isometric scenes.
         this.ceiling.SetActive(!this.isPassiveScene);
 
-
         // Reset the floorProperties in case the previous scene was intuitivePhysics.
         if (this.currentScene.floorProperties == null || !this.currentScene.floorProperties.enable) {
             this.currentScene.floorProperties = new MCSConfigPhysicsProperties();
@@ -399,43 +385,7 @@ public class MCSMain : MonoBehaviour {
 
         // Expand the walls of the room in all intuitive physics scenes and set a specific performer start.
         if (this.currentScene.intuitivePhysics || this.currentScene.observation) {
-            this.wallLeft.transform.position = new Vector3(MCSMain.INTUITIVE_PHYSICS_WALL_LEFT_POSITION_X,
-                MCSMain.WALL_POSITION_Y, MCSMain.WALL_LEFT_RIGHT_POSITION_Z);
-            this.wallLeft.transform.localScale = new Vector3(MCSMain.WALL_LEFT_RIGHT_SCALE_X,
-                MCSMain.WALL_SCALE_Y, MCSMain.WALL_LEFT_RIGHT_SCALE_Z);
-
-            this.wallRight.transform.position = new Vector3(MCSMain.INTUITIVE_PHYSICS_WALL_RIGHT_POSITION_X,
-                MCSMain.WALL_POSITION_Y, MCSMain.WALL_LEFT_RIGHT_POSITION_Z);
-            this.wallRight.transform.localScale = new Vector3(MCSMain.WALL_LEFT_RIGHT_SCALE_X,
-                MCSMain.WALL_SCALE_Y, MCSMain.WALL_LEFT_RIGHT_SCALE_Z);
-
-            this.wallFront.transform.position = new Vector3(MCSMain.WALL_BACK_FRONT_POSITION_X,
-                MCSMain.INTUITIVE_PHYSICS_WALL_FRONT_POSITION_Y, MCSMain.WALL_FRONT_POSITION_Z);
-            this.wallFront.transform.localScale = new Vector3(MCSMain.INTUITIVE_PHYSICS_WALL_BACK_FRONT_SCALE_X,
-                MCSMain.INTUITIVE_PHYSICS_WALL_FRONT_SCALE_Y, MCSMain.WALL_BACK_FRONT_SCALE_Z);
-
-            this.wallBack.transform.position = new Vector3(MCSMain.WALL_BACK_FRONT_POSITION_X,
-                MCSMain.WALL_POSITION_Y, MCSMain.WALL_BACK_POSITION_Z);
-            this.wallBack.transform.localScale = new Vector3(MCSMain.INTUITIVE_PHYSICS_WALL_BACK_FRONT_SCALE_X,
-                MCSMain.WALL_SCALE_Y, MCSMain.WALL_BACK_FRONT_SCALE_Z);
-
-            this.floor.transform.localScale = new Vector3(MCSMain.INTUITIVE_PHYSICS_FLOOR_SCALE_X,
-                MCSMain.FLOOR_SCALE_Y, MCSMain.FLOOR_SCALE_Z);
-
-            this.currentScene.performerStart = new MCSConfigTransform();
-            this.currentScene.performerStart.position = new MCSConfigVector();
-            this.currentScene.performerStart.position.y = MCSMain.INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Y;
-            this.currentScene.performerStart.position.z = MCSMain.INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Z;
-            this.currentScene.performerStart.rotation = new MCSConfigVector();
-
-            // Override the default or configured floorProperties for all intuitivePhysics scenes.
-            this.currentScene.floorProperties = new MCSConfigPhysicsProperties();
-            this.currentScene.floorProperties.enable = true;
-            this.currentScene.floorProperties.dynamicFriction = MCSMain.PHYSICS_FRICTION_DYNAMIC_PASSIVE;
-            this.currentScene.floorProperties.staticFriction = MCSMain.PHYSICS_FRICTION_STATIC_PASSIVE;
-            this.currentScene.floorProperties.bounciness = MCSMain.PHYSICS_BOUNCINESS_DEFAULT;
-            this.currentScene.floorProperties.drag = MCSMain.RIGIDBODY_DRAG_DEFAULT;
-            this.currentScene.floorProperties.angularDrag = MCSMain.RIGIDBODY_ANGULAR_DRAG_DEFAULT;
+            SetupIntuitivePhysics();
         } else if (this.currentScene.isometric) {
             SetupIsometric();
         } else {
@@ -840,6 +790,37 @@ public class MCSMain : MonoBehaviour {
         }
 
         this.CleanupFloorAfterCloning();
+    }
+
+    private void SetupIntuitivePhysics() {
+        bool oldScene = this.currentScene.version < 3;
+
+        // Override the default or configured roomDimensions for all intuitivePhysics scenes.
+        // Please note that the ceiling is deactivated elsewhere.
+        // New scenes are intentionally deeper than old scenes.
+        Vector3 roomDimensions = oldScene ? MCSMain.DEFAULT_ROOM_DIMENSIONS_INTUITIVE_PHYSICS_OLD :
+            MCSMain.DEFAULT_ROOM_DIMENSIONS_INTUITIVE_PHYSICS;
+        SetRoomInternalSize(roomDimensions, WALL_WIDTH);
+
+        // Override the default or configured performerStart for all intuitivePhysics scenes.
+        // The performer agent's position is intentionally higher than floor-level.
+        this.currentScene.performerStart = new MCSConfigTransform();
+        this.currentScene.performerStart.position = new MCSConfigVector();
+        this.currentScene.performerStart.position.y = MCSMain.INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Y;
+        this.currentScene.performerStart.position.z = MCSMain.INTUITIVE_PHYSICS_PERFORMER_START_POSITION_Z;
+        this.currentScene.performerStart.rotation = new MCSConfigVector();
+
+        // Override the default or configured floorProperties for all intuitivePhysics scenes.
+        // The floor intentionally has lower friction than the default floor.
+        this.currentScene.floorProperties = new MCSConfigPhysicsProperties();
+        this.currentScene.floorProperties.enable = true;
+        this.currentScene.floorProperties.dynamicFriction = MCSMain.PHYSICS_FRICTION_DYNAMIC_INTUITIVE_PHYSICS;
+        this.currentScene.floorProperties.staticFriction = MCSMain.PHYSICS_FRICTION_STATIC_INTUITIVE_PHYSICS;
+        this.currentScene.floorProperties.bounciness = MCSMain.PHYSICS_BOUNCINESS_DEFAULT;
+        this.currentScene.floorProperties.drag = MCSMain.RIGIDBODY_DRAG_DEFAULT;
+        this.currentScene.floorProperties.angularDrag = MCSMain.RIGIDBODY_ANGULAR_DRAG_DEFAULT;
+
+        this.currentScene.wallProperties = null;
     }
 
     private void SetupIsometric() {


### PR DESCRIPTION
Changed the hard-coded room dimensions for passive physics scenes so that the room is deeper in scenes with version >= 3. The room will remain the old size for scenes from Evals 2 - 4. I'll update the hypercube scene generator shortly to use this new version number in future passive physics scenes.

Updates to integration tests: https://github.com/NextCenturyCorporation/MCS/pull/573