### PR TITLE
MCS-1341 Check if target is visible at start

### DIFF
--- a/unity/Assets/Scripts/AgentManager.cs
+++ b/unity/Assets/Scripts/AgentManager.cs
@@ -1348,6 +1348,7 @@ public struct MetadataWrapper
 	public Dictionary<string, bool> hapticFeedback;
 	public string resolvedObject;
 	public string resolvedReceptacle;
+	public bool targetIsVisibleAtStart;
 }
 
 [Serializable]

--- a/unity/Assets/Scripts/MCSController.cs
+++ b/unity/Assets/Scripts/MCSController.cs
@@ -1194,11 +1194,12 @@ public class MCSController : PhysicsRemoteFPSAgentController {
             Vector3 direction = p - transform.position;
             if (Physics.Raycast(transform.position, direction, out hit, Vector3.Distance(p, transform.position), 1 << 8))
             {
-                //Debug.DrawRay(transform.position, direction, Color.yellow, 10f);
-                Debug.DrawLine(transform.position, hit.point, Color.red, 10f);
+                //Debug red lines to show lines that dont hit the target, debug green for the raycast that does
+                
+                //Debug.DrawLine(transform.position, hit.point, Color.red, 10f);
                 if (hit.transform.name == retrievalTargetGameObject.name) {
+                    //Debug.DrawLine(transform.position, hit.point, Color.green, 10f);
                     this.targetIsVisibleAtStart = true;
-                    Debug.DrawLine(transform.position, hit.point, Color.green, 10f);
                     return;
                 }
             }

--- a/unity/Assets/Scripts/MCSMain.cs
+++ b/unity/Assets/Scripts/MCSMain.cs
@@ -325,6 +325,9 @@ public class MCSMain : MonoBehaviour {
             }
         }
 
+        agentController.targetIsVisibleAtStart = false;
+        if (CheckIfGoalTargetExists())
+            StartCoroutine(CheckIfTargetIsVisible());
         // Update the camera properties to "reset" the camera and fix a weird rendering issue.
         // Please note it's important to avoid arbitrarily changing the clipping plane values.
         // We use them on the Python side for depth map data conversions, and AIs also use them.
@@ -333,9 +336,27 @@ public class MCSMain : MonoBehaviour {
         
         this.lastStep = -1;
         this.physicsSceneManager.SetupScene();
+        agentController.targetIsVisibleAtStart = false;
     }
 
+
     // Custom Private Methods
+    private IEnumerator CheckIfTargetIsVisible()
+    {
+        // Wait 2 frames for the object to spawn
+        yield return new WaitForEndOfFrame();
+        yield return new WaitForEndOfFrame();
+        string targetId = this.currentScene.goal.metadata.target.id;
+        this.agentController.CheckIfTargetIsVisibleAtStart();
+    }
+
+    private bool CheckIfGoalTargetExists()
+    {
+        return (this.currentScene.goal != null && 
+                this.currentScene.goal.metadata != null && 
+                this.currentScene.goal.metadata.target != null && 
+                this.currentScene.goal.metadata.target.id != null);
+    }
 
     private void AdjustRoomStructuralObjects() {
         String ceilingMaterial = (this.currentScene.ceilingMaterial != null &&
@@ -1140,6 +1161,8 @@ public class MCSMain : MonoBehaviour {
         // NOTE: The objectConfig applies to THIS object and the objectDefinition applies to ALL objects of this type.
 
         gameObject.name = objectConfig.id;
+        if (CheckIfGoalTargetExists() && gameObject.name == this.currentScene.goal.metadata.target.id)
+            agentController.retrievalTargetGameObject = gameObject;
         gameObject.tag = "SimObj"; // AI2-THOR Tag
         gameObject.layer = 8; // AI2-THOR Layer SimObjVisible
         // Add all new objects to the "Objects" object because the AI2-THOR SceneManager seems to care.
@@ -2615,6 +2638,17 @@ public class MCSConfigTeleport : MCSConfigStepBegin {
 [Serializable]
 public class MCSConfigGoal {
     public string description;
+    public MCSConfigGoalMetadata metadata;
+}
+
+[Serializable]
+public class MCSConfigGoalMetadata {
+    public MCSConfigGoalTarget target;
+}
+
+[Serializable]
+public class MCSConfigGoalTarget {
+    public string id;
 }
 
 [Serializable]


### PR DESCRIPTION
After testing different configurations, waiting two frames at the beginning is necessary for this to work. Keep in mind, this is not two physics steps but rather two unity update frames. I dont know how big of an issue this is but it was the only way I could get this to work for now. Without it the object would not spawn in in time for it to be detected. _Note_, even though the agent is looking at the object in the pictures, even if it was turned 180 degrees the raycasts still work and it will detect that it is visible


TOP OF THE OBJECT IS VISIBLE
![Screenshot from 2022-05-17 12-53-18](https://user-images.githubusercontent.com/52011587/168870523-412d2bb4-777c-41c2-98c5-67f1cf4c51da.png)



NOT VISIBLE
![Screenshot from 2022-05-17 12-56-00](https://user-images.githubusercontent.com/52011587/168870516-aefe4b8c-1c91-41db-8185-285359af1e32.png)



