### PR TITLE
Performer stuck on moving agents

### DIFF
--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -960,15 +960,16 @@ namespace UnityStandardAssets.Characters.FirstPerson
                                 return true;
                             }
 
-                            //The performer sometimes gets stuck on simulation agent colliders so if the performer is moving in a direction
-                            //where it should clear the simulation agent, let the performer move.
+                            //The performer sometimes gets stuck on a simulation agent's collider if the simulation agent is moving, 
+                            //so if the performer is moving in a direction where it should clear the simulation agent, 
+                            //like moving backward if the simulation agent is in front of the performer, let the performer move.
                             MCSSimulationAgent simulationAgent = res.transform.GetComponent<MCSSimulationAgent>();
                             if (simulationAgent != null) {
                                 Vector3 directionTowardAgent = simulationAgent.transform.position - transform.position;
                                 float angle = Vector2.Angle(new Vector2(directionTowardAgent.x, directionTowardAgent.z), new Vector2(dir.x, dir.z));
-                                if (angle >= 45) {
+                                float minimumAngleDifferenceNeccesaryForMovement = 45f;
+                                if (angle >= minimumAngleDifferenceNeccesaryForMovement)
                                     continue;
-                                }
                             }
                             int thisAgentNum = agentManager.agents.IndexOf(this);
                             errorMessage = res.transform.name + " is blocking Agent " + thisAgentNum.ToString() + " from moving " + orientation;

--- a/unity/Assets/Scripts/BaseFPSAgentController.cs
+++ b/unity/Assets/Scripts/BaseFPSAgentController.cs
@@ -897,7 +897,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             CapsuleCastInfoByShootingRayToFloor(out p1, out p2, out radius);
             RaycastHit[] hits = Physics.CapsuleCastAll(p1, p2, radius, dir, moveMagnitude, 1<<8, QueryTriggerInteraction.Ignore);
 
-            bool hasNoBlockingObjectsInWay = AgentCanMoveRayCastSweep(ref moveMagnitude, orientation, hits);
+            bool hasNoBlockingObjectsInWay = AgentCanMoveRayCastSweep(ref moveMagnitude, orientation, hits, dir);
             return hasNoBlockingObjectsInWay;
         }
 
@@ -905,7 +905,7 @@ namespace UnityStandardAssets.Characters.FirstPerson
             return rigidbody.mass <= this.GetComponent<Rigidbody>().mass;
         }
 
-        private bool AgentCanMoveRayCastSweep(ref float moveMagnitude, int orientation, RaycastHit[] sweepResults)
+        private bool AgentCanMoveRayCastSweep(ref float moveMagnitude, int orientation, RaycastHit[] sweepResults, Vector3 dir)
         {
             if (sweepResults.Length > 0)
             {
@@ -958,7 +958,18 @@ namespace UnityStandardAssets.Characters.FirstPerson
                             if(ShootRay45DegreesUp(this.inputDirection, moveMagnitude) && structureObject != null) 
                             {
                                 return true;
-                            }     
+                            }
+
+                            //The performer sometimes gets stuck on simulation agent colliders so if the performer is moving in a direction
+                            //where it should clear the simulation agent, let the performer move.
+                            MCSSimulationAgent simulationAgent = res.transform.GetComponent<MCSSimulationAgent>();
+                            if (simulationAgent != null) {
+                                Vector3 directionTowardAgent = simulationAgent.transform.position - transform.position;
+                                float angle = Vector2.Angle(new Vector2(directionTowardAgent.x, directionTowardAgent.z), new Vector2(dir.x, dir.z));
+                                if (angle >= 45) {
+                                    continue;
+                                }
+                            }
                             int thisAgentNum = agentManager.agents.IndexOf(this);
                             errorMessage = res.transform.name + " is blocking Agent " + thisAgentNum.ToString() + " from moving " + orientation;
                             //the moment we find a result that is blocking, return false here


### PR DESCRIPTION
[MCS](https://github.com/NextCenturyCorporation/ai2thor/pull/251)
Sometimes when the performer was walking into a moving agent in my agent identification hypercube scenes, the agent would get stuck and be unable to move backward after colliding. 

To see what I mean, you can run the new integration test 148 on dev to see the performer get obstructed from moving left right or back when it clearly should be able to. Run that same test on this branch to see that the performer can move left, right, and back, when it is not obstructed by the agent in those directions.